### PR TITLE
fix: Resolve velite build errors blocking blog post publication

### DIFF
--- a/content/blog/comparisons/figure-02-vs-tesla-optimus-comparison.md
+++ b/content/blog/comparisons/figure-02-vs-tesla-optimus-comparison.md
@@ -1,5 +1,6 @@
 ---
 title: "Figure 02 vs Tesla Optimus: Which AI Humanoid Robot Leads? (2026)"
+slug: "figure-02-vs-tesla-optimus-comparison"
 date: 2026-01-30
 author: awesome-robots-team
 category: buying-guides

--- a/content/blog/comparisons/unitree-g1-vs-h1-comparison.md
+++ b/content/blog/comparisons/unitree-g1-vs-h1-comparison.md
@@ -1,8 +1,9 @@
 ---
 title: "Unitree G1 vs H1: Which Humanoid Robot is Better? (2026)"
+slug: "unitree-g1-vs-h1-comparison"
 date: 2026-01-30
 author: "awesome-robots-team"
-category: "Comparisons"
+category: "buying-guides"
 tags: ["unitree-g1", "unitree-h1", "comparison", "humanoid", "unitree"]
 excerpt: "Detailed comparison of Unitree G1 vs H1 humanoid robots. Compare specs, pricing ($16K vs $150K), DOF (43 vs 21), and real-world performance to choose the right robot for your research or industrial needs."
 featured: true


### PR DESCRIPTION
## 🐛 Fix Build Errors Blocking DEWALT Blog Post

### Problem
The DEWALT autonomous drilling robot blog post (PR #10, merged) is **not appearing on the live site** because velite build was failing with 5 errors.

### Root Cause
Two comparison blog posts had schema validation errors:
1. `figure-02-vs-tesla-optimus-comparison.md` - missing required `slug` field
2. `unitree-g1-vs-h1-comparison.md` - missing `slug` + invalid category value

### Solution
✅ Added `slug: "figure-02-vs-tesla-optimus-comparison"` to Figure 02 vs Optimus post  
✅ Added `slug: "unitree-g1-vs-h1-comparison"` to G1 vs H1 post  
✅ Fixed category from `"Comparisons"` to `"buying-guides"` (schema-valid enum)

### Velite Error Reduction
**Before:** 5 errors (build partially succeeds but missing posts)  
**After:** 2 errors (non-blocking EISDIR warnings only)

### Verification
```bash
$ npm run build
✓ Compiled successfully
✓ Generating static pages (138/138)
# DEWALT post now included in build
```

### Impact
Once merged, the **DEWALT blog post will appear** on the live site at:  
`/blog/dewalt-autonomous-drilling-robot-data-centers`

Also fixes publication of the two comparison guides.

---
*Created by Clawd Bot (@bob02ship) | Critical fix for blog visibility*