### PR TITLE
feat: Add share buttons to blog posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -105,7 +105,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
       </Script>
       
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <BlogPost post={post} author={author} />
+        <BlogPost post={post} author={author} url={postUrl} />
 
         {/* Related Posts */}
         {relatedPosts.length > 0 && (

--- a/src/components/blog/BlogPost.tsx
+++ b/src/components/blog/BlogPost.tsx
@@ -1,13 +1,15 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import type { Post, Author } from '#site/content'
+import ShareButtons from './ShareButtons'
 
 interface BlogPostProps {
   post: Post
   author?: Author
+  url: string
 }
 
-export default function BlogPost({ post, author }: BlogPostProps) {
+export default function BlogPost({ post, author, url }: BlogPostProps) {
   const formatDate = (date: string) => {
     return new Date(date).toLocaleDateString('en-US', {
       year: 'numeric',
@@ -92,6 +94,11 @@ export default function BlogPost({ post, author }: BlogPostProps) {
           </div>
         </div>
 
+        {/* Share Buttons */}
+        <div className="mb-8">
+          <ShareButtons title={post.title} url={url} excerpt={post.excerpt} />
+        </div>
+
         {/* Featured Image */}
         {post.image && (
           <div className="relative h-64 md:h-96 mb-8 rounded-xl overflow-hidden">
@@ -121,6 +128,12 @@ export default function BlogPost({ post, author }: BlogPostProps) {
                    prose-td:border prose-td:border-gray-300 prose-td:p-2"
         dangerouslySetInnerHTML={{ __html: post.content }}
       />
+
+      {/* Share Buttons */}
+      <div className="mt-12 pt-8 border-t border-gray-200">
+        <h3 className="text-sm font-medium text-gray-900 mb-4">Share this article:</h3>
+        <ShareButtons title={post.title} url={url} excerpt={post.excerpt} />
+      </div>
 
       {/* Tags */}
       {post.tags.length > 0 && (

--- a/src/components/blog/ShareButtons.tsx
+++ b/src/components/blog/ShareButtons.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState } from 'react'
+
+interface ShareButtonsProps {
+  title: string
+  url: string
+  excerpt: string
+}
+
+export default function ShareButtons({ title, url, excerpt }: ShareButtonsProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopyLink = async () => {
+    await navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const encodedTitle = encodeURIComponent(title)
+  const encodedUrl = encodeURIComponent(url)
+  const encodedBody = encodeURIComponent(`${excerpt}\n\n${url}`)
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {/* Twitter/X */}
+      <a
+        href={`https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm text-gray-600 bg-gray-100 hover:bg-gray-200 transition-colors"
+      >
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+        Twitter
+      </a>
+
+      {/* Facebook */}
+      <a
+        href={`https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm text-gray-600 bg-gray-100 hover:bg-gray-200 transition-colors"
+      >
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+        </svg>
+        Facebook
+      </a>
+
+      {/* LinkedIn */}
+      <a
+        href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm text-gray-600 bg-gray-100 hover:bg-gray-200 transition-colors"
+      >
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+        </svg>
+        LinkedIn
+      </a>
+
+      {/* Email */}
+      <a
+        href={`mailto:?subject=${encodedTitle}&body=${encodedBody}`}
+        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm text-gray-600 bg-gray-100 hover:bg-gray-200 transition-colors"
+      >
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="2" y="4" width="20" height="16" rx="2" />
+          <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+        </svg>
+        Email
+      </a>
+
+      {/* Copy Link */}
+      <button
+        onClick={handleCopyLink}
+        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm text-gray-600 bg-gray-100 hover:bg-gray-200 transition-colors cursor-pointer"
+      >
+        {copied ? (
+          <svg className="w-4 h-4 text-green-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        ) : (
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        )}
+        <span className={copied ? 'text-green-600' : ''}>{copied ? 'Copied!' : 'Copy Link'}</span>
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add a reusable `ShareButtons` client component with Twitter/X, Facebook, LinkedIn, Email, and Copy Link buttons
- Display share buttons in two locations on blog posts: below the title/meta info and after the post content
- Copy Link button provides "Copied!" feedback with a 2-second reset

## Test plan
- [ ] Navigate to any blog post and verify share buttons appear in both locations
- [ ] Click each social share link (Twitter, Facebook, LinkedIn, Email) and verify it opens the correct URL
- [ ] Click "Copy Link" and verify clipboard contains the post URL with "Copied!" feedback
- [ ] Check responsive layout on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)