### PR TITLE
Daily post: URKL World's First Humanoid Robot Combat League (2026-02-16)

### DIFF
--- a/content/blog/urkl-humanoid-robot-combat-league-engineai-t800.md
+++ b/content/blog/urkl-humanoid-robot-combat-league-engineai-t800.md
@@ -1,0 +1,170 @@
+---
+title: "URKL: World's First Humanoid Robot Combat League Launches with $1.4M Gold Belt Prize"
+slug: "urkl-humanoid-robot-combat-league-engineai-t800"
+date: "2026-02-16"
+author: "bob-jiang"
+category: "news"
+tags: ["URKL", "humanoid robots", "robot combat", "EngineAI", "T800", "China robotics", "embodied intelligence", "robot sports"]
+excerpt: "The Ultimate Robot Knockout Legend debuts in Shenzhen with free T800 robots for teams, a gold championship belt worth $1.4M, and a mission to accelerate humanoid robotics through real-world combat testing."
+featured: true
+published: true
+seo:
+  title: "URKL Robot Combat League: $1.4M Gold Belt & Free T800 Robots"
+  description: "World's first humanoid robot combat league URKL launches in Shenzhen with EngineAI T800 robots, offering teams free hardware and a $1.4M championship prize to accelerate robotics innovation."
+  keywords: ["URKL", "humanoid robot combat", "EngineAI T800", "robot combat league", "Shenzhen robotics", "embodied intelligence", "robot kung fu", "physical AI"]
+---
+
+## Introduction
+
+On February 9, 2026, Shenzhen witnessed the launch of something unprecedented in robotics history: the **Ultimate Robot Knockout Legend (URKL)**, the world's first commercial free-combat competition designed exclusively for humanoid robots. Organized by Shenzhen EngineAI Robotics Technology Co., Ltd., URKL combines competitive sports spectacle with hardcore technological validation, offering participating teams free T800 humanoid robots and a championship prize that defies expectations—a 10-kilogram pure gold belt valued at approximately **RMB 10 million ($1.44 million)**.
+
+This is not your typical robotics competition. While BattleBots and Robot Wars pioneered remote-controlled combat machines in the late 1990s, URKL represents a quantum leap forward: **autonomous, full-scale humanoid robots** executing martial arts techniques in real-time combat scenarios. With 450 N•m of peak torque, 360-degree aerial rotations, and flying sidekicks, the EngineAI T800 robots competing in URKL are pushing the boundaries of what embodied intelligence can achieve in high-dynamic, unpredictable environments.
+
+## The Rise of Robot Combat Sports: From BattleBots to Humanoid Kung Fu
+
+### A Brief History of Robot Combat
+
+Robot combat entertainment has captivated audiences for decades. British *Robot Wars* (1998-2003, 2016-2018) and American *BattleBots* (2000-2002, 2015-present) turned remote-controlled combat machines into prime-time television phenomena. These competitions featured wheeled, tracked, and multi-legged robots armed with flippers, hammers, and spinning weapons—engineering showcases that demonstrated mechanical design, motor control, and strategic combat thinking.
+
+However, these traditional robot combat formats shared a critical limitation: **remote human control**. Human pilots operated the machines via joysticks, making split-second decisions while robots executed pre-programmed mechanical actions. There was no autonomous decision-making, no dynamic balance recovery, no real-time adaptation to opponent movements.
+
+### The Humanoid Revolution
+
+URKL fundamentally transforms this paradigm. By centering competition around **full-scale humanoid robots** capable of martial arts movements, the league creates unprecedented technical challenges:
+
+- **Dynamic Balance**: Maintaining stability while executing high-impact kicks, punches, and aerial maneuvers
+- **Real-Time Motion Planning**: Generating and executing complex movement sequences in milliseconds
+- **Impact Resistance**: Absorbing strikes while preserving sensor integrity and joint functionality
+- **Autonomous Decision-Making**: Processing opponent movements and selecting appropriate counter-techniques
+
+As EngineAI founder and CEO Zhao Tongyang explained at the launch conference, URKL creates "high-intensity, real-world combat scenarios, serving as a vital platform for core technology validation, product iteration, and talent incubation."
+
+## EngineAI T800: The Robot Built for Combat
+
+### Technical Specifications
+
+The **EngineAI T800** represents the cutting edge of dynamic humanoid robotics. Key specifications include:
+
+- **Peak Torque**: Up to 450 N•m (Newton-meters)
+- **Instantaneous Joint Peak Power**: 14,000 W (watts)
+- **High-DOF Architecture**: Advanced degrees of freedom in neck, waist, and hands
+- **Martial Arts Capabilities**: 360-degree aerial rotations, flying kicks, boxing maneuvers, sidekicks
+- **Anthropomorphic Mobility**: Industry-leading dynamic output and load-handling capacity
+
+Introduced at **CES 2026** in January, the T800 demonstrated its capabilities through live martial arts performances that showcased not just raw power, but sophisticated motion control and body coordination. Unlike industrial robots optimized for repetitive precision tasks, the T800 is engineered for **unpredictable, high-impact scenarios**—exactly what combat competition demands.
+
+### From Exhibition to Validation Platform
+
+What makes URKL strategically brilliant is its dual role as both **entertainment spectacle** and **technical accelerator**. By providing T800 robots free of charge to participating teams, EngineAI lowers barriers to entry while creating a distributed innovation ecosystem.
+
+Tian Feng, former dean of SenseTime's Intelligence Industry Research Institute, told the *Global Times*: "The event covers many metrics such as motion control, dynamic balance, and impact resistance, serving as a high-pressure testbed for key components such as reducers, lead screws, and dexterous hand tendons."
+
+Industry data suggests that real-world combat scenarios can **shorten technology iteration cycles by more than 30 percent**, accelerating the transition from laboratory simulation to physical validation.
+
+## The "Chinese Robot Kung Fu" Model
+
+### Cultural Integration Meets Industrial Strategy
+
+URKL's positioning as a "Chinese Robot Kung Fu" competition reflects more than marketing flair—it represents a strategic fusion of **cultural identity** with **technological advancement**. By centering the league around martial arts, EngineAI creates a uniquely Chinese narrative that resonates domestically while offering international appeal.
+
+Zhao Tongyang emphasized this cultural dimension at the launch: "Through this competition, the company hopes to create a unique format inspired by Chinese robot kung fu, serving as an important bridge connecting Chinese culture with international pop culture and infusing global industrial development with Chinese ingenuity."
+
+This approach mirrors China's broader strategy in robotics: leveraging domestic scale, cultural differentiation, and rapid iteration to establish leadership in emerging technology categories.
+
+### The Gold Belt Strategy
+
+The **RMB 10 million ($1.44 million) gold championship belt** isn't just a prize—it's a statement of intent. Symbolic of "the highest honor in the humanoid robotics field," according to Zhao Tongyang, the belt signals that URKL aims to rival traditional sporting championships in prestige and public attention.
+
+Compare this to typical robotics competition prizes, which range from $10,000 to $100,000. URKL's 14x increase positions the league as a **career-defining opportunity** for robotics engineers, potentially attracting top talent from academia and industry.
+
+## Market Context: China's Humanoid Robot Ambitions
+
+### The 870 Billion Yuan Vision
+
+URKL launches against the backdrop of China's aggressive push into humanoid robotics. According to the **Chinese Institute of Electronics**, China's humanoid robot market is projected to reach **870 billion yuan ($125 billion) by 2030**.
+
+This market expansion is driven by multiple factors:
+
+1. **Industrial Automation**: Labor shortages in manufacturing driving demand for flexible, human-like automation
+2. **Service Applications**: Elderly care, hospitality, and retail seeking human-compatible robots
+3. **Policy Support**: Government initiatives prioritizing embodied intelligence and robotics innovation
+4. **Competitive Momentum**: Post-CES 2026 surge in humanoid robot announcements (Apptronik $520M, Alibaba RynnBrain, Figure Helix 02)
+
+### From Lab to League: The Application Gap
+
+Pan Helin, a Beijing-based analyst, noted a critical challenge facing the industry: "Humanoid robots still face technological and practical limitations, and real-world application is key to their further development."
+
+URKL directly addresses this gap. Rather than waiting for mature technology to find applications, the league creates **high-stakes, high-visibility application scenarios** that force rapid iteration. As Pan explained: "Such events could yield positive effects in the entertainment and performance market, which is a necessary step forward in paving the way for further applications in factories or households."
+
+## Technical Challenges and Innovation Opportunities
+
+### What Robot Combat Tests
+
+URKL's combat format creates unique technical stress tests:
+
+1. **High-Impact Dynamics**: Absorbing and recovering from strikes tests structural integrity, sensor resilience, and control algorithms
+2. **Real-Time Opponent Modeling**: Processing opponent movements requires computer vision, prediction algorithms, and strategic planning
+3. **Energy Management**: Balancing high-power movements with battery constraints
+4. **Failure Recovery**: Maintaining functionality after component damage or system errors
+5. **Multi-Modal Integration**: Coordinating vision, proprioception, force feedback, and motion control
+
+These challenges map directly to real-world application requirements. A robot that can recover from combat strikes can handle industrial accidents. A robot that can predict opponent movements can navigate unpredictable human environments. A robot optimized for energy efficiency in combat can operate longer in service roles.
+
+### The Optimization Risk
+
+Tian Feng cautioned that combat-focused optimization carries risks: "Combat scenarios demand extreme high-impact and short-burst performance, risking the deviation of robot optimization away from mainstream industrial or service applications."
+
+This tension between specialized combat performance and general-purpose capability will be critical to monitor. Will URKL teams prioritize winning at the expense of broader applicability? Or will the competition's visibility drive innovations that benefit the entire robotics ecosystem?
+
+Tian's perspective: "The competition's role is to 'plant seeds,' not to 'harvest.'" In other words, URKL's success should be measured not by immediate commercial applications, but by **long-term talent development, technical breakthroughs, and ecosystem growth**.
+
+## The 2026 Season and Beyond
+
+### Competition Structure
+
+URKL's inaugural 2026 season will follow a tiered competition schedule running through December. Regular matches will be hosted at the **Longgang FRL Robot Club** in Shenzhen, with support from local authorities to establish normalized operational mechanisms.
+
+Teams receive T800 robots free of charge, enabling "practical hands-on development" without the capital barriers that typically limit robotics innovation. This democratization of access could prove transformative, particularly for university research teams and startups.
+
+### Beyond the Arena
+
+EngineAI positions URKL as "a comprehensive industrial platform integrating technological collaboration, resource consolidation, talent development, and capital engagement." The league aims to build a closed-loop ecosystem spanning "R&D – Manufacturing – Application – Investment."
+
+This ambition extends far beyond robot combat. By attracting media attention, investor interest, and engineering talent, URKL could accelerate:
+
+- **Component Innovation**: Reducers, actuators, and sensors optimized for dynamic performance
+- **Software Breakthroughs**: Motion planning, real-time control, and autonomous decision-making algorithms
+- **Talent Pipeline**: Training engineers through hands-on combat scenarios
+- **Standards Development**: Industry-wide benchmarks for humanoid robot capabilities
+
+## Global Implications and the Future of Physical AI
+
+### The Real Steel Moment
+
+URKL inevitably draws comparisons to *Real Steel*, the 2011 film depicting human-piloted robot boxing. But URKL represents something more significant than Hollywood fantasy realized—it's a glimpse of **autonomous physical AI** operating in chaotic, adversarial environments.
+
+As embodied intelligence advances, the gap between entertainment, industrial application, and real-world autonomy continues to narrow. The same algorithms enabling a robot to execute a flying sidekick could enable warehouse robots to navigate dynamic environments, surgical robots to adapt to unexpected anatomy, or search-and-rescue robots to traverse disaster zones.
+
+### The International Response
+
+China's first-mover advantage in humanoid robot combat competitions raises questions for the global robotics community. Will Western robotics companies embrace similar competitive formats? Will URKL expand internationally, creating global championships?
+
+The event has already attracted international attention, with renowned Thai boxing champion **Buakaw Banchamek** delivering remarks at the launch conference—a symbolic bridge between traditional martial arts and robotic combat sports.
+
+## Conclusion: Punching Above Weight
+
+The Ultimate Robot Knockout Legend represents more than robot entertainment—it's a **strategic bet on acceleration through competition**. By combining free hardware, million-dollar prizes, cultural resonance, and technical validation, URKL creates a unique ecosystem for advancing humanoid robotics.
+
+Whether the league succeeds in its ambitious goals—talent development, technology iteration, ecosystem growth—will depend on execution details we won't see for months or years. But the fundamental premise is sound: **high-stakes competition accelerates innovation** in ways that laboratory research alone cannot.
+
+As China's humanoid robot industry races toward its 870 billion yuan vision, URKL offers teams, engineers, and investors a concentrated testing ground for the technologies that will define physical AI's next decade. The robots stepping into the ring in Shenzhen aren't just fighting for gold belts—they're validating the future of human-robot coexistence.
+
+And in an industry still searching for its breakthrough moment, a well-placed flying kick might be exactly what's needed.
+
+---
+
+**Sources:**
+- [URKL Launch Announcement - GlobeNewswire](https://www.globenewswire.com/news-release/2026/02/11/3236473/0/en/World-s-First-Humanoid-Robot-Combat-League-URKL-Officially-Launched.html)
+- [Global Times Coverage](https://www.globaltimes.cn/page/202602/1355090.shtml)
+- [EngineAI T800 at CES 2026 - PRNewswire](https://www.prnewswire.com/news-releases/engineai-robotics-technology-introduces-the-t800-humanoid-robot-at-ces-2026-302655094.html)
+- [Humanoid Combat History - Humanoids Daily](https://www.humanoidsdaily.com/feed/humanoid-robots-enter-the-fighting-ring-a-new-era-of-combat-sports)


### PR DESCRIPTION
## Summary
World's first humanoid robot combat league URKL launches in Shenzhen with EngineAI T800 robots, $1.4M gold championship belt, and free robots for teams.

## Topic
Covers URKL launch (Feb 9, 2026), EngineAI T800 specifications (450 N•m torque, martial arts capabilities), cultural strategy (Chinese robot kung fu), technical validation platform, and China's 870 billion yuan humanoid robot market vision.

## Keywords
URKL, humanoid robots, robot combat, EngineAI, T800, China robotics, embodied intelligence, robot sports, martial arts, competitive robotics