### PR TITLE
Daily post: Unitree plans to ship 20,000 humanoid robots in 2026 (2026-02-19)

### DIFF
--- a/content/blog/unitree-20000-humanoid-robots-2026.md
+++ b/content/blog/unitree-20000-humanoid-robots-2026.md
@@ -1,0 +1,282 @@
+---
+title: "Unitree Plans to Ship 20,000 Humanoid Robots in 2026: The Real Meaning of Mass Production"
+slug: "unitree-20000-humanoid-robots-2026"
+date: "2026-02-19"
+author: "bob-jiang"
+category: "news"
+tags: ["humanoid robots", "Unitree", "embodied AI", "robot manufacturing", "robotics", "China", "industrial automation"]
+excerpt: "Unitree says it aims to ship around 20,000 humanoid robots in 2026—here is why that number matters, what has to be true to hit it, and what it signals for embodied AI." 
+featured: true
+published: true
+seo:
+  title: "Unitree 20,000 Humanoid Robots in 2026: Mass Production Shift"
+  description: "Unitree targets ~20,000 humanoid robot shipments in 2026. Learn what mass production requires, where deployment is realistic, and what it means for embodied AI."
+  keywords: ["Unitree humanoid robots", "20,000 humanoid robots 2026", "embodied AI", "humanoid robot manufacturing", "robot deployment", "G1 humanoid"]
+---
+
+## Introduction: a number that forces the industry to grow up
+
+Humanoid robotics has spent decades living in a comfortable limbo: spectacular demos, tiny pilot programs, and endless debates about whether the human form factor is a gimmick or the inevitable endgame.
+
+A shipment target changes that conversation.
+
+Multiple reports this week say **Unitree Robotics is aiming to ship around 20,000 humanoid robots in 2026**, up from an estimated **~5,500 humanoids shipped last year** (per market research cited in coverage). If that happens, it will be one of the first times a humanoid company crosses from “we can build robots” to “we can run a product business at scale.”
+
+This article breaks down what that scale actually implies:
+
+- What has to be true (engineering, supply chain, reliability, economics)
+- Which near-term deployments are realistic (and which are still stage magic)
+- Why embodied AI teams should care even if they never buy a humanoid
+
+## What Unitree showcased (and why it matters)
+
+Unitree’s humanoids grabbed attention with increasingly athletic public demonstrations, including **complex performance routines** highlighted in Lunar New Year programming. The specifics (flips, coordinated choreography, martial-arts-style sequences) are less important than the meta-signal:
+
+- The robots are getting **faster and more stable**
+- The hardware is surviving **high-speed, high-impact cycles**
+- Multi-robot coordination is becoming more repeatable (still staged, but improving)
+
+A controlled stage is not a factory floor. But it does offer one key data point: **the platform is robust enough to be thrown at aggressive motion tasks without instantly tearing itself apart**.
+
+That is a prerequisite for real deployment.
+
+## “Ship 20,000” is not a PR line — it is a manufacturing statement
+
+When a robotics company says it plans to ship tens of thousands of units, the hard part is rarely “can the robot walk.” The hard part is **the boring machinery of productization**:
+
+### 1) Supply chain readiness
+
+At low volumes, you can survive with:
+
+- Custom machining
+- Hand-assembled wiring harnesses
+- Part substitutions
+- Hero engineers living inside a test lab
+
+At 20,000 units, you need:
+
+- Stable suppliers for actuators, batteries, sensors, compute modules, and safety components
+- Tight incoming QC (quality control) so the variance does not kill performance
+- Predictable lead times so you can plan builds and service inventory
+
+If your joints vary by a few percent across batches, the control stack suffers. If your IMUs drift differently, your state estimation suffers. “Mass production” forces those problems into the open.
+
+### 2) Reliability engineering, not demo engineering
+
+Demos optimize for moments. Deployments optimize for uptime.
+
+A large shipment plan implies Unitree believes it can:
+
+- Standardize assemblies so robots behave similarly
+- Improve MTBF (mean time between failures)
+- Replace fragile parts with maintainable modules
+- Ship service procedures, spares, and diagnostic tooling
+
+This is where many robotics programs stall. A robot that can run a 60-second routine is not automatically a robot that can work 8 hours per day.
+
+### 3) Test automation and calibration at scale
+
+Every humanoid needs calibration:
+
+- Joint offsets
+- Motor current sensing
+- IMU alignment
+- Force/torque estimation (even without explicit sensors)
+- Vision sensor intrinsics/extrinsics
+
+At small volume, calibration is manual. At large volume, calibration must be a **repeatable factory process**.
+
+A simple rule: if you cannot calibrate a robot in a predictable time window, you cannot ship 20,000 of them.
+
+### 4) A software update and fleet operations story
+
+For real customers, the robot is not a one-time sale. It becomes a living system:
+
+- Security patches
+- Motion-control improvements
+- New skills
+- Telemetry and health monitoring
+
+That means:
+
+- OTA update infrastructure
+- Versioning discipline
+- Rollback capability
+- Customer-safe update rollouts
+
+In other words: **DevOps for bodies**.
+
+## The question everyone should ask: who buys 20,000 humanoids?
+
+The easiest way to misunderstand humanoids is to imagine a near-future where they replace all human labor. That is not how technology adoption works.
+
+If Unitree can ship tens of thousands of units, the deployments are likely to be narrower and more pragmatic.
+
+### Near-term deployment scenarios that actually make sense
+
+**1) Structured industrial environments (the first real beachhead)**
+
+Factories and warehouses have:
+
+- Repetitive layouts
+- Predictable floor conditions
+- Controlled lighting
+- Existing safety procedures
+
+Humanoids do not need to be “general” here. They need to be **good enough at a small set of tasks**.
+
+A realistic early pattern is:
+
+- Human supervises one or more robots
+- Robots handle low-complexity material movement, inspection, or transport
+- Humans handle edge cases and high-dexterity work
+
+**2) Inspection and patrol tasks**
+
+Inspection is attractive because it rewards mobility and perception more than dexterity.
+
+If a humanoid can:
+
+- Walk reliably
+- Carry a sensor payload
+- Read gauges/labels
+- Report anomalies
+
+…it can deliver value without needing hands that rival a human’s.
+
+**3) Research, education, and developer ecosystems**
+
+The quiet engine of robotics progress is “how many teams can experiment.”
+
+If Unitree pushes more units into universities, labs, and startups, it can accelerate:
+
+- Motion policy learning
+- Sim-to-real pipelines
+- Whole-body manipulation research
+- Tooling around fleet operations
+
+This is not as glamorous as factory adoption, but it is how platforms become standards.
+
+### Deployments that are still mostly fantasy (for now)
+
+**1) Unstructured public service work** (hospitality, retail, crowd-facing assistance)
+
+The long tail of edge cases is brutal:
+
+- Wet floors
+- Unexpected obstacles
+- Unpredictable humans
+- Tight spaces, glass walls, reflective surfaces
+
+Even if the robot is physically capable, the safety and reliability bar is extremely high.
+
+**2) Full human replacement workflows**
+
+Humans are not one product. They are a bundle of skills.
+
+If a humanoid is deployed today, it will be deployed to do *one* job (or a small set of jobs), not to be a universal employee.
+
+## Why the humanoid form factor can win anyway
+
+Humanoids are controversial for a reason: wheels are simpler, cheaper, and often better.
+
+But the “human shape” argument is not about aesthetics. It is about **infrastructure compatibility**.
+
+We built the world for humans:
+
+- Stairs
+- Doors
+- Handles
+- Shelves
+- Vehicles
+- Tools
+
+A humanoid that is merely “good enough” at locomotion and light manipulation can access a huge installed base of environments without the environment being rebuilt.
+
+That is the bet.
+
+## The embodied AI implication: the bottleneck is no longer just data
+
+The last year has seen a surge of talk around “embodied AI,” “physical AI,” and robot foundation models. But large-scale deployment is still throttled by three intertwined constraints:
+
+1) **Hardware cost** (can customers afford fleets?)
+2) **Reliability and safety** (can customers trust fleets?)
+3) **Skill generalization** (can fleets adapt without re-engineering?)
+
+A 20,000-unit plan indicates that at least one major player thinks constraint #1 and #2 are improving fast enough to justify aggressive scaling.
+
+That matters because **more robots in the world creates the opportunity for better learning loops**:
+
+- More operational data
+- More failure modes discovered
+- More fleet-level metrics
+- More chances to train, test, and validate policies
+
+It is not guaranteed to produce a foundation model breakthrough. But it does move the industry toward the conditions where such breakthroughs become possible.
+
+## The uncomfortable truth: performance demos are not deployment proofs
+
+It is tempting to watch a video of a robot doing flips and conclude that the deployment problem is solved.
+
+It is not.
+
+A stage routine can be:
+
+- Carefully choreographed
+- Tuned to the surface
+- Rehearsed repeatedly
+- Supported by precomputed trajectories
+- Operated with human oversight or failsafes that would be unacceptable in a customer environment
+
+Real-world deployment is messy. The robot must handle:
+
+- Variation (floors, lighting, obstacles)
+- Wear and tear
+- Minor collisions
+- Batteries that degrade
+- Sensors that drift
+- Customers who treat it like an appliance
+
+So the correct interpretation of Unitree’s target is not “humanoids are solved.”
+
+It is: **someone believes they can turn humanoids into a product category**.
+
+## What to watch in 2026 (the scorecard)
+
+If you want to evaluate whether Unitree (and the broader humanoid market) is truly entering a mass-production era, watch for these signals:
+
+1) **Real customer case studies** with clear ROI
+- Not just “pilot launched,” but measurable productivity or cost reductions
+
+2) **Service and maintenance disclosures**
+- How often do parts fail?
+- How quickly can a technician swap modules?
+
+3) **Software update cadence**
+- Do fleets improve over time?
+- Are updates stable and secure?
+
+4) **Unit economics**
+- Price band and total cost of ownership
+- Battery lifespan and charging logistics
+
+5) **Deployment at multi-site scale**
+- One robot in one lab is easy
+- 100 robots across multiple sites is the real test
+
+## Bottom line
+
+**A target of ~20,000 humanoid shipments in 2026 is a forcing function**. Even if the exact number is optimistic, the ambition signals a shift:
+
+- Humanoid robotics is moving from “demo culture” toward “operations culture”
+- The competition will increasingly be about manufacturing, reliability, and fleet management
+- Embodied AI will be judged by what it can do in the real world, repeatedly, at scale
+
+If Unitree hits anything close to this shipment target, it will accelerate the entire ecosystem—suppliers, software stacks, and customer expectations—toward a future where humanoids stop being a spectacle and start being infrastructure.
+
+## Sources
+
+- StartupNews.fyi: Unitree targets 20,000 humanoid robots in 2026
+  - https://startupnews.fyi/2026/02/18/unitree-20000-humanoid-robots-2026/
+- Interesting Engineering: Unitree targets 20,000 humanoid robots with fourfold capacity expansion plan
+  - https://interestingengineering.com/ai-robotics/unitree-targets-20000-humanoid-robots


### PR DESCRIPTION
## Summary
Unitree reportedly targets ~20,000 humanoid robot shipments in 2026. This post explains why the number matters (manufacturing, reliability, calibration, fleet ops) and what to watch in real deployments.

## Keywords
Unitree, humanoid robots, embodied AI, mass production, fleet operations, China robotics