### PR TITLE
Fix beehiiv newsletter embed URL

### DIFF
--- a/src/components/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup.tsx
@@ -10,7 +10,7 @@ export default function NewsletterSignup({ className }: NewsletterSignupProps) {
   return (
     <div className={className}>
       <iframe
-        src="https://embeds.beehiiv.com/ccd23b92-3d64-4f8c-b267-8a69739700af"
+        src="https://subscribe-forms.beehiiv.com/2ee91aa5-2585-40f5-b43c-d5c2600ea21c"
         data-test-id="beehiiv-embed"
         width="100%"
         height="320"


### PR DESCRIPTION
## Summary
- Fixed the beehiiv iframe `src` URL from an invalid embed ID to the correct subscription form URL
- Previous: `https://embeds.beehiiv.com/ccd23b92-...` (returned "Not found")
- Fixed: `https://subscribe-forms.beehiiv.com/2ee91aa5-2585-40f5-b43c-d5c2600ea21c` (shows "Awesome Robots Digest" form)

## Test plan
- [ ] Verify the newsletter form loads on blog post pages (no "Not found")
- [ ] Verify the newsletter form loads in the footer
- [ ] Test email subscription works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)