### PR TITLE
fix: Validate Discord webhook URL before sending newsletter

### DIFF
--- a/.github/workflows/weekly-digest-newsletter.yml
+++ b/.github/workflows/weekly-digest-newsletter.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Install
         run: npm ci
       - name: Send newsletter to Discord
+        if: ${{ secrets.DISCORD_NEWSLETTER_WEBHOOK_URL != '' }}
         env:
           DISCORD_NEWSLETTER_WEBHOOK_URL: ${{ secrets.DISCORD_NEWSLETTER_WEBHOOK_URL }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}

--- a/scripts/send-weekly-digest-newsletter.ts
+++ b/scripts/send-weekly-digest-newsletter.ts
@@ -151,6 +151,15 @@ async function main() {
   if (!webhookUrl) {
     throw new Error("Missing DISCORD_NEWSLETTER_WEBHOOK_URL secret/env");
   }
+  try {
+    new URL(webhookUrl);
+  } catch {
+    throw new Error(
+      "DISCORD_NEWSLETTER_WEBHOOK_URL is not a valid URL. " +
+      "Please set the repository secret to a full Discord webhook URL " +
+      "(e.g. https://discord.com/api/webhooks/...)."
+    );
+  }
 
   const changed = gitDiffNames(beforeSha, afterSha);
   const digestChanged = changed.filter(isDigestFile);


### PR DESCRIPTION
## Summary
- Fix GitHub Action failure: `TypeError: Failed to parse URL` when `DISCORD_NEWSLETTER_WEBHOOK_URL` is not a valid URL
- Add URL validation in the script with a clear error message pointing to the expected format
- Skip the newsletter step entirely if the secret is not configured (empty string)

## Root cause
The `DISCORD_NEWSLETTER_WEBHOOK_URL` secret exists but contains an invalid URL. `fetch()` throws `TypeError: Invalid URL` which is hard to diagnose from the masked `***` output.

## Action needed after merge
Set the `DISCORD_NEWSLETTER_WEBHOOK_URL` repository secret to a valid Discord webhook URL (e.g. `https://discord.com/api/webhooks/CHANNEL_ID/TOKEN`). You can create one in Discord: Server Settings > Integrations > Webhooks.

## Test plan
- [ ] Verify the workflow skips gracefully when secret is empty
- [ ] Verify the script gives a clear error when URL is invalid
- [ ] Verify newsletter sends successfully with a valid Discord webhook URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)