### PR TITLE
Daily post: Diffusion Transformer Policies (2026-02-22)

### DIFF
--- a/content/blog/diffusion-transformer-policy-on-device-robot-manipulation.md
+++ b/content/blog/diffusion-transformer-policy-on-device-robot-manipulation.md
@@ -1,0 +1,278 @@
+---
+title: "Diffusion Transformer Policies: How On-Device Diffusion Is Making Robot Manipulation Faster and Cheaper"
+slug: "diffusion-transformer-policy-on-device-robot-manipulation"
+date: "2026-02-22"
+author: "bob-jiang"
+category: "tutorials"
+tags: ["robotics", "AI", "robot learning", "diffusion models", "transformers", "manipulation", "edge AI"]
+excerpt: "A practical guide to diffusion-based robot policies, why Diffusion Transformers matter, and how on-device inference changes the economics of real-world manipulation."
+featured: true
+published: true
+seo:
+  title: "Diffusion Transformer Policy for On-Device Robot Manipulation"
+  description: "Learn how diffusion-based policies generate robot actions, why Diffusion Transformers outperform classic behavior cloning, and what on-device diffusion enables."
+  keywords: ["diffusion transformer policy", "diffusion policy robotics", "on-device robot manipulation", "robot learning transformer", "visuomotor policy"]
+---
+
+## Introduction: why diffusion suddenly matters for robots
+
+Robot manipulation has a reputation for being either:
+
+1. **Hand-engineered** (reliable but brittle), or
+2. **Learned in the cloud** (impressive demos but expensive, slow, and hard to deploy).
+
+Diffusion-based policies are one of the most important shifts in the “learned” side because they change *how* actions are produced. Instead of predicting a single best next action (which often collapses to average behavior), diffusion policies learn to model **a distribution over actions** and sample from it.
+
+That sounds like a generative-image trick, but in robotics it fixes a real pain:
+
+- Many tasks have **multiple valid solutions** (grasp from left or right, push then grasp, rotate then lift).
+- Demonstrations can be **multi-modal** (different humans do different things).
+- Sensor noise makes exact next-action prediction unstable.
+
+Diffusion policies take the same core idea that made image generation robust—iterative denoising—and apply it to **action sequences**.
+
+In this post, we will break down:
+
+- What diffusion policies are in robotics (in plain terms)
+- Why **Diffusion Transformers** are a natural next step
+- What “**on-device diffusion policy**” changes for real-world deployment
+- The practical tradeoffs: latency, compute, safety, and reliability
+
+We will also point you to key references, including the original Diffusion Policy work and newer papers on diffusion transformers and efficient/on-device inference.
+
+## The baseline: behavior cloning and why it plateaus
+
+The simplest way to learn robot manipulation from demonstrations is **behavior cloning (BC)**:
+
+- Input: observations (images, proprioception, language)
+- Output: the next action (joint targets, end-effector delta, gripper open/close)
+- Training: supervised learning on demonstration pairs
+
+BC works, but it often fails in three common ways:
+
+### 1) “Averaging” kills multi-modal behavior
+If your dataset includes two equally-good strategies, a deterministic model tends to predict an average that is **not executable**.
+
+Example: if half the demos grasp from the left and half from the right, the averaged grasp might be straight into the object.
+
+### 2) Long-horizon compounding errors
+A small error at time step 20 becomes a bigger distribution shift by time step 60.
+
+### 3) Action distributions are weird
+Robot actions are not nicely unimodal Gaussians. They can be discontinuous (contact, slip) and depend on latent factors (friction, object pose).
+
+Diffusion-based policies attack all three by learning a richer action distribution and by predicting **a whole action chunk** instead of a single action.
+
+## Diffusion Policy 101 (robot version)
+
+If you have seen diffusion models for images, the loop is:
+
+- Start with noise
+- Iteratively denoise
+- End with a clean sample
+
+In robotics, the “image” is replaced by an **action trajectory**.
+
+### What is sampled?
+Typically, the policy samples a sequence of actions over a horizon:
+
+- **Action chunk**: e.g. 8–32 steps
+- Each step could be joint velocities, end-effector deltas, or other control commands
+
+So instead of predicting a single next action, the model predicts a *plan-ish* chunk of actions conditioned on the current observation.
+
+### What does the model learn?
+The model learns how to reverse a noising process on trajectories:
+
+- Forward process: take expert action chunks and add noise across timesteps
+- Reverse process: learn to remove noise and recover a plausible expert-like chunk
+
+This gives you two big wins:
+
+1. You can represent **multiple valid futures**.
+2. You tend to get **smoother, more consistent motion** because the sampled chunk is internally coherent.
+
+A canonical reference is Columbia’s Diffusion Policy page, which benchmarks diffusion policies across manipulation tasks and reports strong performance versus common baselines:
+
+- Diffusion Policy (project): https://diffusion-policy.cs.columbia.edu/
+
+## Why the next step is a Diffusion Transformer
+
+Early diffusion policies often used convolutional or MLP-ish backbones with temporal conditioning. But robots are inherently **sequence + context** problems:
+
+- Temporal dependencies across the horizon
+- Cross-modal conditioning (vision, proprioception, language)
+- Variable task complexity
+
+Transformers are strong at:
+
+- Modeling sequences
+- Attending to the relevant parts of history
+- Scaling with data
+
+A **Diffusion Transformer** combines:
+
+- Diffusion-style denoising of action trajectories
+- Transformer attention over time (and sometimes across modalities)
+
+Conceptually:
+
+- The diffusion process defines *how* you sample actions
+- The transformer defines *how* you model dependencies in those actions (and what conditioning matters)
+
+In the literature you will see names like:
+
+- Diffusion trajectory-guided policy (DTP) for long-horizon tasks (OpenReview, 2024):
+  https://openreview.net/forum?id=VaoeAi5CW8
+- Diffusion-transformer-style policies and scaling discussions in later conference papers (e.g., ICCV/CVPR-era work)
+
+## The deployment problem: diffusion is good, but it is slow
+
+Here is the uncomfortable truth: **diffusion sampling costs steps**.
+
+Even if each denoising step is fast, 10–50 iterations can add up, especially if:
+
+- Your backbone is heavy (transformer)
+- Your robot control loop wants low latency
+- You want to run on embedded hardware (not a datacenter GPU)
+
+That is why “**on-device diffusion transformer policy**” papers are interesting. They try to answer:
+
+> Can we keep the robustness and multi-modal benefits of diffusion while meeting real-time constraints on edge hardware?
+
+One example surfaced in public CVF access:
+
+- On-Device Diffusion Transformer Policy for Efficient Robot Manipulation (ICCV 2025 PDF):
+  https://openaccess.thecvf.com/content/ICCV2025/papers/Wu_On-Device_Diffusion_Transformer_Policy_for_Efficient_Robot_Manipulation_ICCV_2025_paper.pdf
+
+And related scaling/open-source work appears in diffusion transformer policy papers:
+
+- Dita: Scaling Diffusion Transformer for Generalist Vision-Language-Action Policy (ICCV 2025 PDF):
+  https://openaccess.thecvf.com/content/ICCV2025/papers/Hou_Dita_Scaling_Diffusion_Transformer_for_Generalist_Vision-Language-Action_Policy_ICCV_2025_paper.pdf
+
+(Exact details vary per paper, but the shared theme is efficiency + scaling.)
+
+## What “on-device” actually changes
+
+Running a policy on-device is not just a performance flex. It changes the product constraints.
+
+### 1) Latency becomes predictable
+Cloud inference adds variable network delay. On-device inference makes latency mostly a function of compute and scheduling.
+
+For manipulation, **predictable latency** often matters more than raw average latency because:
+
+- Contact dynamics are fast
+- Safety controllers rely on timing assumptions
+
+### 2) Reliability improves in the messy world
+Warehouses, farms, homes: connectivity is inconsistent. If your policy needs the internet, you do not have a product.
+
+### 3) Data privacy and compliance get easier
+On-device processing can simplify privacy concerns when cameras are involved (especially in home settings).
+
+### 4) Cost per robot drops
+Cloud GPUs are expensive. If you are shipping a fleet, on-device compute is often cheaper over time, even if the device BOM is higher.
+
+## The typical engineering tricks to make diffusion policies faster
+
+Most “efficient diffusion” methods boil down to a few knobs:
+
+### A) Fewer denoising steps
+- Use improved schedulers
+- Distill many-step sampling into fewer steps
+
+### B) Smaller or structured backbones
+- Use a transformer, but keep it narrow
+- Use temporal attention only where needed
+- Share weights across steps
+
+### C) Action chunking and receding horizon control
+Instead of sampling 100 steps, sample 16 steps and re-plan every 4–8 steps.
+
+This also acts like an implicit feedback loop.
+
+### D) Quantization and deployment optimization
+- INT8 / mixed precision
+- Kernel fusion
+- Static shapes where possible
+
+### E) Conditioning compression
+If you condition on images, the vision encoder can dominate cost. Many systems:
+
+- Precompute image features
+- Use lightweight visual backbones
+- Cache features across denoising iterations
+
+## When diffusion policies beat classic policies (and when they do not)
+
+### They shine when:
+
+- The task is **multi-modal** (many valid approaches)
+- Demonstrations are diverse
+- Contact-rich motion needs smoothness
+- You want a generalist policy with broad behavior coverage
+
+### They struggle when:
+
+- You need ultra-low latency with high-frequency control
+- Your dataset is small and narrow (a simpler BC model may be enough)
+- The environment requires strong state estimation and classical feedback
+
+A pragmatic take: diffusion is not replacing control theory. It is replacing the brittle “single next action regression” layer in learned manipulation systems.
+
+## A practical mental model: diffusion policy as a constraint-satisfying sampler
+
+Think of a diffusion policy as a sampler that tries to satisfy multiple soft constraints:
+
+- “The trajectory should look like expert behavior”
+- “It should be consistent with the current observation”
+- “It should fit the task conditioning (language, goal image, etc.)”
+
+Sampling gives you the freedom to represent diverse strategies, which can be crucial in manipulation.
+
+If you want to go further, you can add additional constraints:
+
+- collision checks
+- torque limits
+- velocity limits
+
+This is one direction where hybrid systems will likely win: **diffusion proposes**, **safety filters verify**.
+
+## How to evaluate diffusion transformer policies (what to measure)
+
+If you are building or choosing a policy, measure more than success rate:
+
+1. **Success rate** across tasks and object variations
+2. **Time-to-success** (efficiency)
+3. **Trajectory smoothness** (jerk, acceleration)
+4. **Recovery behavior** after perturbations
+5. **Latency distribution** (p50, p95, worst-case)
+6. **Compute footprint** (watts, memory)
+7. **Safety incidents** (collisions, excessive forces)
+
+On-device work forces you to care about #5 and #6.
+
+## What to watch next (2026 and beyond)
+
+Three trends are converging:
+
+### 1) Generalist VLA policies + diffusion-style action generation
+Vision-language-action policies want broad coverage and multi-modality. Diffusion fits naturally.
+
+### 2) Robotics compute stacks are maturing
+Edge accelerators, better runtimes, and better quantization make on-device more realistic.
+
+### 3) Safety and determinism will become mandatory
+As these policies leave labs, we will see more safety wrappers, verification layers, and deterministic fallbacks.
+
+My bet: the winners will be the teams that treat diffusion as a **component** in a full robot stack (perception, planning, control, safety), not as a standalone magic model.
+
+## References and further reading
+
+- Diffusion Policy (Columbia): https://diffusion-policy.cs.columbia.edu/
+- Diffusion Trajectory-guided Policy (OpenReview 2024): https://openreview.net/forum?id=VaoeAi5CW8
+- On-Device Diffusion Transformer Policy for Efficient Robot Manipulation (ICCV 2025):
+  https://openaccess.thecvf.com/content/ICCV2025/papers/Wu_On-Device_Diffusion_Transformer_Policy_for_Efficient_Robot_Manipulation_ICCV_2025_paper.pdf
+- Dita: Scaling Diffusion Transformer for Generalist Vision-Language-Action Policy (ICCV 2025):
+  https://openaccess.thecvf.com/content/ICCV2025/papers/Hou_Dita_Scaling_Diffusion_Transformer_for_Generalist_Vision-Language-Action_Policy_ICCV_2025_paper.pdf
+- Awesome list (diffusion in robotics): https://github.com/showlab/Awesome-Robotics-Diffusion


### PR DESCRIPTION
## Summary
A practical guide to diffusion-based robot policies, why diffusion transformers matter, and what on-device inference changes for real-world manipulation.

## Keywords
Diffusion Policy, diffusion transformers, on-device inference, robot manipulation, visuomotor learning

## Notes
- Front matter follows awesomerobots rules (double quotes, excerpt, published).
- References included to Diffusion Policy + ICCV 2025 diffusion transformer papers.