### PR TITLE
Daily post: Touch Dreaming for Humanoid Manipulation (2026-04-17)

### DIFF
--- a/content/blog/touch-dreaming-humanoid-manipulation-htd.md
+++ b/content/blog/touch-dreaming-humanoid-manipulation-htd.md
@@ -1,0 +1,258 @@
+---
+title: "Touch Dreaming: Why Predicting Future Tactile Latents Makes Humanoid Manipulation Finally Work"
+slug: "touch-dreaming-humanoid-manipulation-htd"
+date: "2026-04-17"
+author: "bob-jiang"
+category: "tutorials"
+tags: ["humanoid robots", "tactile sensing", "imitation learning", "transformers", "behavior cloning", "dexterous manipulation", "teleoperation"]
+excerpt: "A deep dive into HTD (Humanoid Transformer with Touch Dreaming) and why predicting future touch in latent space can dramatically improve contact-rich humanoid loco-manipulation."
+featured: true
+published: true
+seo:
+  title: "Touch Dreaming for Humanoid Manipulation (HTD) Explained"
+  description: "Learn how Humanoid Transformer with Touch Dreaming (HTD) uses future tactile-latent prediction plus whole-body RL control to boost success on contact-rich humanoid manipulation tasks."
+  keywords: ["touch dreaming", "HTD", "humanoid manipulation", "tactile latents", "contact-rich manipulation", "behavior cloning", "whole-body control"]
+---
+
+## The problem: vision-only humanoid policies are blind right when it matters
+
+Humanoid manipulation looks impressive in demos until the moment *contact* becomes the main signal.
+
+If you are inserting a part with millimeter clearance, folding a towel that constantly changes shape, or scooping with a tool in a cramped space, the robot’s camera view is not enough. In those moments:
+
+- Small pose errors turn into *jams*, *slips*, or *dropped objects*.
+- The “state” changes abruptly when contact switches (touch/no-touch, edge contact, sliding contact, etc.).
+- Good actions depend on forces you can’t reliably infer from pixels.
+
+That is why tactile sensing has been repeatedly shown to help. But it’s also why tactile learning is annoyingly hard in practice: raw tactile signals are high-dimensional, noisy, hardware-dependent, and difficult to integrate into policies without multi-stage training or extra inference-time modules.
+
+A new paper from CMU + Bosch Center for AI proposes a clean idea with a very practical flavor:
+
+**Don’t just *use* touch—make the policy learn to *predict* future touch (in latent space) while learning actions.**
+
+That approach is called **Humanoid Transformer with Touch Dreaming (HTD)**, introduced in:
+
+- Paper: https://arxiv.org/abs/2604.13015
+- Project page (videos + extra details): https://humanoid-touch-dream.github.io/
+
+The headline result is big: across five real-world, contact-rich tasks, HTD reports a **90.9% relative improvement in average success rate** over a strong baseline (ACT) on the same platform.
+
+This post breaks down what “touch dreaming” is, why predicting *latent* touch matters, and what this work suggests about the next generation of humanoid manipulation systems.
+
+---
+
+## What HTD is trying to solve (in one sentence)
+
+**HTD aims to make humanoid manipulation robust under frequent contact changes by combining**:
+
+1. **Stable whole-body execution** (an RL-based whole-body controller to keep the base/torso reliable while hands do hard work)
+2. **Scalable data collection** (VR teleoperation + motion mapping for demos)
+3. **Contact-aware representation learning** (a Transformer policy trained with action prediction *and* future-touch prediction)
+
+The key is that HTD treats touch as a first-class modality *and* uses “touch dreaming” as an auxiliary objective.
+
+---
+
+## Step 1: You still need the boring stuff — a stable humanoid platform
+
+Before “better learning” can matter, you need a body that behaves predictably.
+
+The authors emphasize an integrated real-world system for **whole-body humanoid loco-manipulation**:
+
+- An **RL-based whole-body controller (WBC)** for stable lower body + torso execution
+- A **teleoperation stack** (VR-based) with human-to-humanoid motion mapping
+- **Upper-body IK** + **dexterous-hand retargeting**
+- **Distributed tactile sensing** on the hands
+
+Why this matters: many policy failures that look like “the model is bad” are actually “the robot is unstable.” If the lower body and torso drift while the hands are trying to align a part, you are injecting noise into every demonstration and every rollout.
+
+HTD’s learning improvements are built on top of a controller designed to make the humanoid a decent substrate for imitation learning.
+
+---
+
+## Step 2: The tasks are designed to punish non-contact-aware policies
+
+HTD is evaluated on five real-world tasks that are *deliberately* contact rich:
+
+1. **Insert-T**: tight-tolerance insertion (reported clearance ~3.5 mm on the project page)
+2. **Book Organization**: manipulating thin rigid objects with limited grasp affordances
+3. **Towel Folding**: long-horizon deformable object manipulation
+4. **Cat Litter Scooping**: tool-mediated contact under low-profile constraints
+5. **Tea Serving**: bimanual fetch + transport while maintaining stability and keeping objects balanced
+
+If a policy can do these reliably, it is much closer to “useful” humanoid manipulation than a policy that only succeeds on open-space pick-and-place.
+
+---
+
+## The core model: a multimodal Transformer policy for humanoid loco-manipulation
+
+At a high level, HTD is a **multimodal encoder–decoder Transformer**.
+
+**Inputs (modalities):**
+
+- Multi-view **vision** (robot cameras)
+- **Proprioception** (joint states, etc.)
+- **Touch** (tactile signals)
+
+**Outputs:**
+
+- **Action chunks** (rather than a single action per step)
+
+Chunked action prediction is common in modern imitation learning because it helps with temporal consistency and reduces myopic action noise.
+
+So far, nothing magical.
+
+The magic is in training: HTD learns actions *and* learns to dream about future touch.
+
+---
+
+## What “touch dreaming” actually means
+
+“Touch dreaming” is an auxiliary training objective:
+
+Along with predicting the next actions, HTD is trained to predict **future contact-related signals**, specifically:
+
+- **Future hand-joint forces**
+- **Future tactile representations (latents)**
+
+This forces the shared Transformer trunk to learn representations that *explain contact dynamics*, not just appearances.
+
+If you have seen ideas like JEPA-style predictive learning (predict future embeddings without reconstructing raw pixels), the flavor is similar: you want the model’s internal state to capture the causal structure of the world.
+
+But here, the target is not future video—it is future touch.
+
+That is a big deal because touch is often closer to “ground truth interaction state” than vision.
+
+---
+
+## Why predicting tactile *latents* beats predicting raw tactile signals
+
+The paper reports that **latent-space tactile prediction is more effective than raw tactile prediction**, with an ablation showing roughly a **30% relative gain in success rate** for latent tactile dreaming compared to raw tactile prediction (as summarized in the abstract and visualized on the project page).
+
+That matches a practical intuition:
+
+- **Raw tactile signals** are hardware-dependent and can be hard to model directly.
+- A learned **latent** can compress away sensor quirks and focus on contact-relevant features (pressure distribution “shape,” contact region activation, slip-like patterns, etc.).
+
+If you want generalizable manipulation, you usually want the policy to reason in terms of *contact states* (where contact is happening, how strong it is, whether it is changing), not in terms of thousands of raw taxel readings.
+
+### The EMA target encoder trick (why it matters)
+
+A common pitfall in predictive latent learning is collapse or instability: if the latent target keeps moving, the predictor can chase noise.
+
+HTD uses an **Exponential Moving Average (EMA) target encoder** to generate stable latent targets for the tactile prediction objective (described in the arXiv HTML version).
+
+This keeps training **single-stage** and avoids requiring separate pretraining of a tactile encoder.
+
+That single-stage nature is underrated. Lots of tactile learning papers work in principle but are operationally messy:
+
+- “Pretrain a tactile model for N days, then freeze it, then train the policy.”
+- “Train a world model, then do MPC-style planning with it.”
+- “Use a separate inference-time module.”
+
+HTD’s claim is basically: *keep deployment simple; use prediction objectives to shape representations during training.*
+
+---
+
+## A mental model for why touch dreaming helps
+
+Here’s a concrete way to think about it.
+
+In contact-rich manipulation, the robot needs to answer questions like:
+
+- “Am I pushing on the object or sliding along it?”
+- “Did I catch the lip of the socket or am I misaligned?”
+- “Is the towel edge under my finger or just visually nearby?”
+
+These are **interaction** questions, not perception questions.
+
+Touch dreaming provides supervision for interaction.
+
+If the policy can predict what touch will look like *in a few moments*, it implicitly has to model:
+
+- Geometry + alignment
+- Compliance
+- Frictional contact modes
+- Tool-object coupling
+- Whole-body effects (small torso drift → different contact outcome)
+
+That makes the policy’s internal state less likely to be “pretty but useless.”
+
+It also reduces the temptation to overfit to camera cues that correlate with success in the training set but don’t generalize.
+
+---
+
+## Why this matters specifically for humanoids (not just robot arms)
+
+Most tactile learning progress has been on arm-hand platforms.
+
+Humanoids are harder because:
+
+- The hands are attached to a moving, balancing body.
+- Manipulation changes the whole-body dynamics.
+- Success depends on foot support, torso posture, and hand forces simultaneously.
+
+The paper explicitly frames humanoid manipulation as requiring tight coordination between:
+
+- Whole-body stability
+- Dexterous hands
+- Contact-aware perception
+
+Touch dreaming is a neat fit for humanoids because it “connects” these subsystems: it punishes representations that ignore contact outcomes, which often depend on whole-body motion.
+
+---
+
+## What to take seriously (and what to be skeptical about)
+
+### Take seriously
+
+1. **The task set is legit.** Insertions, deformables, and tool use are where real robots die.
+2. **Auxiliary objectives are a powerful lever.** If you can shape representations without making inference more complex, you usually should.
+3. **Latent prediction is the right direction.** Predicting raw tactile time series is like predicting raw pixels—possible, but often the wrong abstraction.
+
+### Be skeptical / open questions
+
+1. **Embodiment specificity.** How well does HTD transfer to other humanoids with different hands/tactile layouts?
+2. **Data scale.** VR teleop is scalable *relative to* fully manual robot programming, but it is still labor-intensive.
+3. **Failure modes.** The project page notes some hardware issues (e.g., intermittent communication failures in a hand during some rollouts). Real systems always have these.
+
+Still, the direction is clear: contact-aware learning is not optional for high-dexterity manipulation.
+
+---
+
+## If you are building humanoid manipulation systems: practical implications
+
+If you are working on real-world humanoid manipulation, HTD suggests a recipe that is worth copying:
+
+1. **Make the body stable first.** A strong whole-body controller is not “engineering overhead”—it’s the base of your learning pipeline.
+2. **Treat touch as core, not auxiliary.** Touch shouldn’t just be an extra input; it should shape the representation.
+3. **Use predictive objectives to learn contact dynamics.** Predicting the future is a surprisingly effective way to force the model to learn the right abstractions.
+4. **Prefer latent targets over raw reconstruction.** It is usually more robust and more transferable.
+
+---
+
+## The bigger picture: toward contact-native “foundation policies”
+
+In the last two years, robotics has moved rapidly toward Transformer-based, multimodal policies trained on large datasets.
+
+But there is a looming mismatch:
+
+- Large datasets tend to be heavy on vision.
+- Real manipulation reliability depends heavily on contact.
+
+Touch dreaming is one concrete way to close that gap without turning your system into a complicated stack.
+
+If the next generation of humanoid “foundation policies” is going to be reliable, it probably needs something like:
+
+- touch-native representations
+- predictive interaction learning
+- whole-body execution that is strong enough to keep the data distribution sane
+
+HTD is an early, convincing step in that direction.
+
+---
+
+## Sources
+
+- Niu et al., “Learning Versatile Humanoid Manipulation with Touch Dreaming” (arXiv:2604.13015): https://arxiv.org/abs/2604.13015
+- Project page (videos, ablations, extra metrics): https://humanoid-touch-dream.github.io/


### PR DESCRIPTION
## Summary
Deep dive into HTD (Humanoid Transformer with Touch Dreaming) and why predicting future tactile latents improves contact-rich humanoid loco-manipulation.

## Sources
- https://arxiv.org/abs/2604.13015
- https://humanoid-touch-dream.github.io/

## Notes
Category: tutorials
Word count: ~1661