### PR TITLE
Daily post: StreamingVLA and FocusVLA (2026-04-19)

### DIFF
--- a/content/blog/streamingvla-focusvla-real-time-vla-robots.md
+++ b/content/blog/streamingvla-focusvla-real-time-vla-robots.md
@@ -1,0 +1,218 @@
+---
+title: "StreamingVLA and FocusVLA: How to Make Vision-Language-Action Models Fast Enough for Real Robots"
+slug: "streamingvla-focusvla-real-time-vla-robots"
+date: "2026-04-19"
+author: "bob-jiang"
+category: "tutorials"
+tags: ["robotics", "VLA", "vision-language-action", "edge AI", "humanoid robots", "robot learning", "real-time control"]
+excerpt: "A practical, engineering-focused guide to reducing latency and wasted compute in VLA robot policies—based on StreamingVLA’s pipelined execution and FocusVLA’s task-relevant visual attention."
+featured: true
+published: true
+seo:
+  title: "StreamingVLA and FocusVLA: Real-Time VLA Models for Robots"
+  description: "Learn how StreamingVLA pipelines observation→generation→execution and how FocusVLA selects task-relevant visual tokens—two key ideas for running VLA policies on real robots."
+  keywords: ["StreamingVLA", "FocusVLA", "vision-language-action", "robot policy latency", "edge robotics"]
+---
+
+## The real VLA problem is not “can it do the task?”—it’s “can it do the task *on time*?”
+
+Vision-Language-Action (VLA) models have been getting better at mapping instructions + camera input to robot actions. But if you try to run a large VLA policy on a real robot, you hit an ugly reality that benchmark papers often hide:
+
+- Your control loop has deadlines (often 10–50 Hz for meaningful interaction).
+- Your GPU is not an A100 in a datacenter—it’s a constrained edge system.
+- Your robot cannot “pause and think” mid-motion without looking broken (or unsafe).
+
+That’s why a March 2026 cluster of papers is interesting: they treat VLA as an *engineering discipline*, not just a modeling problem. In particular:
+
+- **StreamingVLA** re-architects execution so observation encoding, action generation, and action execution overlap instead of blocking each other. It reports a **2.4× latency speedup** and **6.5× reduction in execution halting** in their evaluation.\
+  Source: *StreamingVLA: Streaming Vision-Language-Action Model with Action Flow Matching and Adaptive Early Observation* (arXiv:2603.28565). [arXiv](https://arxiv.org/abs/2603.28565)
+
+- **FocusVLA** argues that many VLA policies waste most compute on **task-irrelevant visual tokens**, then proposes attention mechanisms that emphasize task-relevant patches and suppress noise.
+
+Both ideas are useful even if you’re not reproducing those exact papers—because they point to two failure modes that show up *everywhere* in VLA deployments:
+
+1) **Serial stalling** (the robot waits for the model)\
+2) **Token bloat** (the model pays for pixels it doesn’t need)
+
+This post is a practical guide to those failure modes, how StreamingVLA / FocusVLA address them, and how you can apply the same thinking in your own robot stack.
+
+> Primary reading reference for the paper summaries below: the Robotics arXiv Digest (2026-03-30) which collected and summarized StreamingVLA, FocusVLA, and related evaluation work like ManipArena.\
+> Digest: https://www.visionforrobotics.com/robotics-digest/digest_2026-03-30.html
+
+---
+
+## 1) Why classic VLA execution “halts” (and why halting is a bigger deal than raw latency)
+
+Most VLA systems, even if the model is strong, run like this:
+
+1. **Encode observation** (RGB-D, proprioception, language instruction)
+2. **Generate action** (often autoregressively, sometimes as a chunk)
+3. **Execute action** on the robot
+4. Repeat
+
+The problem is that **the stages are typically sequential**. Your robot starts each step by waiting for the full encode, then waiting for action generation, *then* executing. If step 2 takes longer than your control interval, the robot starts to visibly “stutter.”
+
+That stutter isn’t just aesthetic:
+
+- It breaks contact-rich behaviors (closing a gripper while tracking slip, inserting a peg, turning a knob).
+- It makes compliance harder (your force controller gets stale targets).
+- It increases the safety envelope you need (because reaction time is worse).
+
+In other words, **the real KPI is not average latency—it’s how often you miss deadlines.**
+
+### A useful mental model: the “action-execution gap”
+
+The Robotics arXiv Digest summary frames a key metric: the **action-execution gap**—the portion of time where the robot is forced to pause because the next action is not ready.
+
+Reducing that gap is the fastest path to making VLA behaviors look “robotic” in the good way (smooth, responsive), instead of “robotic” in the bad way (jerky, indecisive).
+
+---
+
+## 2) StreamingVLA: pipeline the loop like a real-time system
+
+StreamingVLA’s core claim is simple: **stop treating observation→generation→execution as a strict chain**. Instead, treat it like a pipeline where multiple timesteps are in flight.
+
+### The idea: overlap stages
+
+Instead of:
+
+- t0: encode obs0 → generate act0 → execute act0
+- t1: encode obs1 → generate act1 → execute act1
+
+You do something closer to:
+
+- Encode obs(t) while executing act(t-1)
+- Generate act(t) while executing act(t)
+
+This sounds obvious (every real-time system does pipelining), but many VLA stacks don’t, because the “model forward pass” is treated like a monolithic black box.
+
+### Two technical choices worth stealing
+
+**(A) Replace action chunking with smoother streaming generation**
+
+A common trick for large policies is **action chunking**: predict a sequence of actions (say 10 steps), then execute them without re-querying the model.
+
+Chunking hides compute latency, but it has a nasty drawback: you commit to a future that may quickly become wrong.
+
+StreamingVLA reports using **action flow matching** instead—learning a *continuous action stream* that can be produced and consumed while execution is ongoing. The key point isn’t the specific method; the point is the *design goal*: avoid “bursty” planning that forces open-loop execution.
+
+**(B) Start generating actions before full observation encoding finishes**
+
+StreamingVLA also describes an “adaptive early observation” mechanism: begin action generation when there’s “enough” visual context, rather than waiting for the full encode. Again, the transferable idea is: treat perception compute as something you can **progressively refine**, not something you must complete before acting.
+
+### What to do in your own stack (even without rewriting your model)
+
+You can apply the StreamingVLA mindset without implementing their full architecture:
+
+- **Split model inference into components**: vision encoder, language encoder, policy head. Cache what you can.
+- **Use a rolling buffer**: always keep a “next action” ready; if a new action arrives late, blend or replace.
+- **Add a real-time governor**: if inference runs long, degrade gracefully (e.g., hold last action, switch to impedance control, or fall back to a classical controller) rather than halting.
+
+If you do nothing else, implement one rule:
+
+> Never let the robot wait on the model in the middle of motion.
+
+---
+
+## 3) FocusVLA: compute is wasted on pixels (and “bigger vision encoders” can be the wrong fix)
+
+A second failure mode is more subtle: **even if your model is fast, you may be spending most of that compute on the wrong parts of the image**.
+
+The FocusVLA summary in the Robotics arXiv Digest calls out three compounding issues in many VLA architectures:
+
+1. **Attention over-smoothing**: the model averages over too many visual tokens.
+2. **Token count bloat**: too many visual tokens dilute the signal.
+3. **Task-irrelevant visual noise**: the policy is distracted by background regions.
+
+This matters because VLA policies are often used on *visually busy* scenes: tables with clutter, warehouse shelves, factory floors. If your model processes everything uniformly, you pay a huge cost for irrelevant patches.
+
+### Key takeaway: utilization beats representation
+
+The FocusVLA claim is provocative: performance can be limited more by **how visual information is used** than by the “quality” of the visual encoder.
+
+That has a strong implication for builders:
+
+- Before you scale up to a bigger vision backbone, consider **token selection / relevance filtering / attention shaping**.
+
+In practice, this is often cheaper and yields bigger wins on edge hardware.
+
+### What “task-relevant token selection” means in robotics
+
+In robotics, relevance is not just “salient” like in generic VLM benchmarks. It’s grounded in:
+
+- The instruction ("pick up the red cup")
+- The robot state (where the gripper is)
+- The stage of the task (approach vs grasp vs lift)
+
+A simple heuristic approach already helps:
+
+- Crop or zoom around the gripper workspace.
+- Use object detection to keep only regions containing candidate targets.
+- Keep higher resolution only in the action-critical region.
+
+FocusVLA’s direction is basically: make this *learned and differentiable*, so the model itself learns what to focus on.
+
+---
+
+## 4) Don’t optimize VLAs in a simulator vacuum: ManipArena is the warning label
+
+Even if you solve latency and token bloat, you still need to know whether your “improvements” matter on real hardware.
+
+The same Robotics arXiv Digest highlights **ManipArena**, a standardized real-world evaluation framework designed to expose the simulation-to-reality credibility gap. The summary emphasizes that simulator-centric benchmarks can make methods look better than they are, and that real-world tasks reveal issues like:
+
+- contact dynamics
+- sensor noise
+- hardware latency
+- timing mismatches
+
+If your VLA architecture is evaluated only in sim, you can easily optimize for artifacts (rendering cues, overly clean physics) that won’t exist in deployment.
+
+**Practical point:** latency optimizations *must* be tested on the actual target compute and control stack. A 2× speedup in one lab’s software pipeline can vanish when integrated into another.
+
+---
+
+## 5) A practical checklist: making VLA policies “real-robot deployable”
+
+If you want a concrete, implementation-oriented set of moves, here’s a checklist that maps directly to the two themes (streaming + focus):
+
+### A. Eliminate robot waiting (streaming mindset)
+
+- **Measure end-to-end loop time**, not just model inference time.
+- **Track deadline misses** (how often your control tick is late).
+- **Pipeline your stages**: perception, policy, and execution should overlap.
+- **Cache static context**: instruction embeddings, scene features that change slowly.
+- **Have a fallback controller** for late ticks (impedance / MPC / last-action hold).
+
+### B. Reduce wasted compute (focus mindset)
+
+- **Count visual tokens** and compute cost per tick.
+- **Use region-of-interest inputs** (gripper-centric crops).
+- **Downsample background** aggressively.
+- **Prioritize action-relevant sensors** instead of “add everything.” (More sensors can hurt in data-limited regimes—another result discussed in the same digest.)
+
+### C. Evaluate like you plan to deploy
+
+- Test on **the same GPU/CPU budget** you’ll ship.
+- Measure **smoothness / halting / contact failures**, not just success rate.
+- Run tasks that include **timing pressure** (dynamic objects, compliant insertion, bimanual coordination).
+
+---
+
+## Conclusion: VLAs are becoming a systems problem (and that’s good news)
+
+The most important shift in VLA research is not a single model improvement—it’s the move from “look, it works in a demo” to “make it run continuously on a real robot.”
+
+StreamingVLA is a reminder that latency is often a *pipeline design* issue, not just a “need a faster GPU” issue.
+
+FocusVLA is a reminder that compute is often wasted on pixels that don’t affect actions—and that better utilization can beat bigger encoders.
+
+Put together, the message is clear:
+
+> The next jump in robot capability will come from treating VLA as a real-time system with attention budgets—not just a big model.
+
+---
+
+## References
+
+- StreamingVLA (arXiv:2603.28565): https://arxiv.org/abs/2603.28565
+- Robotics arXiv Digest — 2026-03-30 (summaries of StreamingVLA, FocusVLA, ManipArena, and more): https://www.visionforrobotics.com/robotics-digest/digest_2026-03-30.html


### PR DESCRIPTION
## Summary
A practical, engineering-focused guide to making VLA robot policies deployable in real time, drawing on StreamingVLA (pipelined observation→generation→execution) and FocusVLA (task-relevant visual attention) plus lessons from real-world evaluation.

## Category
Tutorials

## Sources
- https://arxiv.org/abs/2603.28565
- https://www.visionforrobotics.com/robotics-digest/digest_2026-03-30.html

## File
- content/blog/streamingvla-focusvla-real-time-vla-robots.md