### PR TITLE
Daily post: VADF Explained (2026-04-23)

### DIFF
--- a/content/blog/vadf-vision-adaptive-diffusion-policy-efficient-robotic-manipulation.md
+++ b/content/blog/vadf-vision-adaptive-diffusion-policy-efficient-robotic-manipulation.md
@@ -1,0 +1,308 @@
+---
+title: "VADF Explained: Vision-Adaptive Diffusion Policies That Train Faster and Run Cheaper"
+slug: "vadf-vision-adaptive-diffusion-policy-efficient-robotic-manipulation"
+date: "2026-04-23"
+author: "bob-jiang"
+category: "tutorials"
+tags: ["robotics", "Diffusion Policy", "robot manipulation", "imitation learning", "efficiency", "VLA", "computer vision"]
+excerpt: "VADF is a vision-driven add-on for diffusion policies that targets two pain points—slow training and expensive inference—using adaptive hard-sample mining and vision-based task segmentation."
+featured: true
+published: true
+seo:
+  title: "VADF Explained: Faster, Cheaper Diffusion Policies for Robots"
+  description: "Learn how VADF improves diffusion-based robot manipulation with adaptive hard-sample mining during training and vision-based task segmentation during inference."
+  keywords: ["VADF", "diffusion policy", "robot manipulation", "imitation learning", "efficient inference", "hard negative mining"]
+---
+
+## TL;DR
+
+Diffusion policies have become one of the most reliable ways to generate smooth, multimodal robot actions—but they’re also expensive: they can take a lot of gradient steps to converge and a lot of denoising steps to run at inference time.
+
+A new arXiv paper proposes **VADF (Vision-Adaptive Diffusion Policy Framework)**, a model-agnostic “bolt-on” that tries to make diffusion manipulation **train faster** and **execute more efficiently** by:
+
+- **Training-time:** predicting which samples are “hard” (high loss) and **sampling them more** (hard-negative mining via a lightweight loss predictor).
+- **Inference-time:** using vision to **segment a task into simpler vs more complex subtasks**, then allocating **shorter denoising schedules** to easy parts and longer schedules only when needed.
+
+Primary source: arXiv:2604.15938 (Apr 17, 2026) — “VADF: Vision-Adaptive Diffusion Policy Framework for Efficient Robotic Manipulation”
+<https://arxiv.org/abs/2604.15938>
+
+Related (same week, similar direction: longer-horizon robustness via planning+reflection): “Goal2Skill” (Apr 16, 2026)
+<https://arxiv.org/html/2604.13942v1>
+
+---
+
+## Why diffusion policies are everywhere (and why they hurt)
+
+If you’ve been following robot learning the past two years, you’ve seen diffusion models show up everywhere: manipulation, locomotion, even multi-robot generalization.
+
+The core appeal is simple:
+
+1. **Actions are multi-modal.** For the same observation, there can be many valid actions. Diffusion models handle this naturally.
+2. **They’re surprisingly stable.** Compared to brittle autoregressive or purely deterministic policies, diffusion often yields smooth trajectories.
+3. **They fit the “foundation policy” narrative.** You can condition on images, proprioception, language, geometry—then sample actions.
+
+But the pain is also simple:
+
+- **Training can be slow.** You’re learning to denoise across many timesteps; gradients are spread out and signal can be dominated by easy regions.
+- **Inference can be slow and compute-heavy.** More denoising steps generally means better quality, but also higher latency—fatal for real robots with tight control loops.
+
+The VADF paper calls out two concrete symptoms:
+
+- **Slow convergence** from uniform sampling and “hard negative class imbalance” (too many easy samples, not enough attention on failure modes).
+- **Inference timeouts** when long noise schedules are used everywhere, even when the current sub-action is trivial.
+
+VADF’s claim: you can keep the strengths of diffusion policies while adapting both training and inference to what vision says is “hard.”
+
+---
+
+## What is VADF?
+
+**VADF (Vision-Adaptive Diffusion Policy Framework)** is presented as **architecture-agnostic**: it’s not “a new diffusion policy,” but a **framework that can wrap existing diffusion policies**.
+
+It has two main components:
+
+1. **ALN (Adaptive Loss Network)** — a lightweight MLP that predicts difficulty during training.
+2. **HVTS (Hierarchical Vision Task Segmenter)** — a vision-driven module for segmenting tasks at inference time.
+
+From the abstract (emphasis added): VADF is a “vision-driven dual-adaptive framework” that aims to reduce convergence steps and “achieve early success in inference.”
+
+Let’s unpack each part and why it might work.
+
+---
+
+## Part 1: ALN — adaptive hard-sample mining for diffusion training
+
+### The problem: uniform sampling wastes compute
+
+Most diffusion-policy training pipelines sample data uniformly (or nearly uniformly) from a dataset of trajectories.
+
+That’s reasonable if:
+
+- the dataset is balanced, and
+- each minibatch contains a healthy mix of edge cases.
+
+But robot datasets aren’t like ImageNet. They often contain:
+
+- lots of near-duplicates,
+- long stretches of “boring” states (steady approach, gripper open, small adjustments), and
+- relatively fewer frames where things go wrong (slippage, collisions, occlusion, object out of reach).
+
+If you sample uniformly, your model spends a lot of its budget getting even better at easy regions.
+
+### The idea: learn which samples are hard, then sample them more
+
+VADF proposes **ALN**, described as a “lightweight MLP-based loss predictor” that estimates **per-step sample difficulty in real time**.
+
+The workflow looks like this:
+
+1. During training, you compute the diffusion loss for samples.
+2. ALN learns to predict which samples/timesteps will produce high loss.
+3. You do a form of **hard negative mining**: **weighted sampling** prioritizes those high-loss regions.
+
+Why this is plausible:
+
+- In diffusion training, different timesteps can be very different in difficulty.
+- Certain scenes/poses can be systematically hard (reflective objects, clutter, unusual lighting).
+- If you can concentrate training on the tails, you can often improve sample efficiency.
+
+### What’s “hard negative class imbalance” here?
+
+In classic classification, “hard negatives” are samples that look like the positive class but are actually negative.
+
+In diffusion manipulation, the analogy is:
+
+- **easy samples:** denoising is straightforward; the policy quickly predicts reasonable actions.
+- **hard samples:** denoising fails more often; the policy produces actions that are slightly off (causing future divergence) or completely wrong.
+
+If your training set contains far more easy samples, the gradient signal from hard samples is underrepresented.
+
+ALN is trying to fix that imbalance without manual curation.
+
+### Practical take: this is the boring part that can matter most
+
+The training trick (adaptive sampling) is not flashy, but it’s the kind of change that can yield real-world ROI:
+
+- fewer steps to reach a useful policy,
+- better coverage of failure modes,
+- faster iteration cycles.
+
+If you’re building a manipulation stack, anything that turns “we need a 3-day retrain” into “we can test variants in hours” changes your entire workflow.
+
+---
+
+## Part 2: HVTS — vision-based task segmentation for cheaper inference
+
+### The problem: a single denoising schedule is a blunt instrument
+
+Diffusion policies typically pick a fixed number of denoising steps at inference.
+
+- Too few: actions are low quality, success rate drops.
+- Too many: actions are great, but latency kills you.
+
+In many real tasks, action difficulty is not constant:
+
+- Reaching toward a clear target in open space is easy.
+- Inserting a peg, aligning a connector, or working around occlusion is hard.
+
+A fixed schedule is like forcing your robot to do maximum-precision planning for every millisecond—even when it’s just moving through free space.
+
+### The idea: segment the task and allocate compute where it matters
+
+VADF’s inference module is **HVTS (Hierarchical Vision Task Segmenter)**.
+
+As described in the abstract:
+
+- It “decomposes high-level task instructions into multi-stage low-level sub-instructions based on visual input.”
+- It segments action sequences into **simple** vs **complex** subtasks.
+- It then assigns:
+  - **shorter noise schedules + longer direct execution** for simple actions
+  - **longer noise schedules + shorter execution** for complex ones
+
+This is essentially **adaptive compute** for diffusion policies.
+
+### Why vision-driven segmentation makes sense
+
+Robots already use perception to decide:
+
+- where to grasp,
+- whether the object is occluded,
+- whether contact has happened,
+- whether alignment is good.
+
+VADF’s claim is: use that same perception signal to decide **how much diffusion compute to spend**.
+
+The goal is not just lower average latency, but higher “early success”—i.e., getting a good enough action quickly without needing to always sample deeply.
+
+### A concrete mental model
+
+Imagine a pick-and-place task in clutter:
+
+1. **Approach region (easy):** move end effector above object.
+2. **Pre-grasp alignment (medium):** orient gripper.
+3. **Contact and closure (hard):** friction/occlusion matters.
+4. **Lift and retreat (easy-medium):** move away.
+
+A fixed schedule would spend the same denoising depth on all four.
+
+A segmented schedule could do:
+
+- 5 denoise steps for approach,
+- 10 for alignment,
+- 25 for contact,
+- 8 for lift.
+
+If your control loop is tight, that can be the difference between “works in sim” and “works on a real arm.”
+
+---
+
+## How VADF fits into the bigger trend: modular stacks (not monoliths)
+
+What’s interesting is that VADF’s inference idea rhymes with a broader direction in robotics right now:
+
+- stop treating the policy as a monolith,
+- add **systems-level structure** around it.
+
+A paper from the same week, **Goal2Skill** (Apr 16, 2026), explicitly argues that long-horizon tasks require:
+
+- persistent memory,
+- adaptive task decomposition,
+- explicit verification and recovery.
+
+It proposes a dual-system setup:
+
+- a VLM-based planner that decomposes goals and reflects on failures,
+- a diffusion-based VLA executor that performs low-level control.
+
+Source: <https://arxiv.org/html/2604.13942v1>
+
+VADF is a different slice of the same cake:
+
+- it doesn’t build a planner, but
+- it **adapts compute and sampling** based on vision-driven difficulty.
+
+The shared thesis: modern robot policies need **wrappers**—memory, segmentation, verification, safety filters, compute schedulers.
+
+---
+
+## What I like about VADF (and what I’d be cautious about)
+
+### What’s compelling
+
+1. **Model-agnostic framing.** If it really plugs into existing diffusion-policy codebases, adoption is much easier.
+2. **Targets real pain points.** Training time and inference latency are the two things that kill diffusion on hardware.
+3. **Adaptive compute is the future.** Not every scene deserves the same budget.
+
+### What I’d watch closely
+
+1. **Complexity creep.** Adding ALN + HVTS adds moving parts. If each part needs tuning, you may lose the simplicity diffusion policies were valued for.
+2. **Failure modes of segmentation.** If HVTS misclassifies a complex subtask as “simple,” you might spend too few steps exactly when you need precision.
+3. **Generalization across tasks and cameras.** Vision-driven difficulty estimation can be brittle if the visual domain shifts.
+
+In practice, the best “efficiency” methods are the ones that degrade gracefully: when they fail, they revert to safe defaults.
+
+---
+
+## Implementation sketch: how you might prototype VADF-style ideas
+
+If you’re building a manipulation policy today and want to test the underlying ideas without fully replicating the paper, here’s a practical approach.
+
+### 1) Training-time adaptive sampling (ALN-lite)
+
+You can approximate ALN with something simpler:
+
+- Maintain a replay buffer of trajectories.
+- Track a running loss per sample (or per trajectory chunk).
+- Sample with probability proportional to that loss (or a temperature-scaled variant).
+
+Even a crude “prioritize high loss” sampler often improves stability and tail performance.
+
+### 2) Inference-time adaptive denoising
+
+Start with a heuristic scheduler:
+
+- If the gripper is far from objects and motion is collision-free → fewer steps.
+- If contact is imminent, occlusion is detected, or alignment error is high → more steps.
+
+Then graduate to a learned predictor (HVTS-like) once you’ve validated the ROI.
+
+### 3) Measure the right metric
+
+Don’t just measure final success rate.
+
+Measure:
+
+- success vs latency tradeoff,
+- early success rate (how often you succeed within a max time budget),
+- worst-case latency (timeouts are what break deployments),
+- tail performance on hard scenes.
+
+---
+
+## What this means for the “diffusion policy on robots” roadmap
+
+The diffusion-policy story is shifting.
+
+The first phase was:
+
+- “diffusion is a strong policy parameterization.”
+
+The next phase is:
+
+- “diffusion needs systems engineering to be deployable.”
+
+VADF is in that second phase:
+
+- smarter training curricula (hard sample mining),
+- smarter inference compute allocation (vision-based segmentation),
+- a push toward real-time feasibility.
+
+If these ideas hold up across robots and datasets, they point toward a future where diffusion policies aren’t just accurate—they’re **operationally efficient**.
+
+---
+
+## References
+
+- VADF paper (Apr 17, 2026): “VADF: Vision-Adaptive Diffusion Policy Framework for Efficient Robotic Manipulation” — arXiv:2604.15938
+  <https://arxiv.org/abs/2604.15938>
+- Goal2Skill paper (Apr 16, 2026): “Goal2Skill: Long-Horizon Manipulation with Adaptive Planning and Reflection” — arXiv:2604.13942
+  <https://arxiv.org/html/2604.13942v1>


### PR DESCRIPTION
## Summary
Explains the new VADF framework (arXiv:2604.15938) and why vision-adaptive training + inference can make diffusion policies more practical on real robot manipulation.

## Key ideas
- ALN: adaptive hard-sample mining via a lightweight loss predictor
- HVTS: vision-based task segmentation to allocate shorter vs longer denoising schedules

## Sources
- https://arxiv.org/abs/2604.15938
- https://arxiv.org/html/2604.13942v1