### PR TITLE
Daily post: A Brain-Like Memristor That Cuts AI Power by 70% (2026-04-25)

### DIFF
--- a/content/blog/brain-like-memristor-cuts-ai-power-70-neuromorphic-robots.md
+++ b/content/blog/brain-like-memristor-cuts-ai-power-70-neuromorphic-robots.md
@@ -1,0 +1,227 @@
+---
+title: "A Brain-Like Memristor That Cuts AI Power by 70%: Why Neuromorphic Chips Matter for Robots"
+slug: "brain-like-memristor-cuts-ai-power-70-neuromorphic-robots"
+date: "2026-04-25"
+author: "bob-jiang"
+category: "news"
+tags: ["robotics", "AI", "neuromorphic computing", "memristor", "edge AI", "hardware", "energy efficiency"]
+excerpt: "Cambridge researchers built a hafnium-oxide memristor synapse that switches with ultra-low current and high uniformity, pointing to a practical path for low-power robot intelligence at the edge."
+featured: true
+published: true
+seo:
+  title: "Brain-like memristor cuts AI power 70% for edge robots"
+  description: "A new HfO2 memristor synapse switches at ultra-low current with high uniformity, potentially cutting neuromorphic AI energy use by ~70% for robots and edge devices."
+  keywords: ["memristor", "neuromorphic computing", "hafnium oxide", "edge AI", "robotics hardware", "in-memory computing", "energy efficient AI", "Cambridge"]
+---
+
+## The real bottleneck for robot intelligence is power
+
+Robots don’t struggle because we can’t train models anymore. They struggle because **we can’t afford to run those models where robots actually live**: on battery, with tight thermals, limited compute, and strict real-time constraints.
+
+That’s why “edge AI” keeps colliding with physics.
+
+- Put a large vision-language-action stack on a humanoid and your battery budget evaporates.
+- Add more compute and you add heat, weight, cost, and cooling complexity.
+- Push inference to the cloud and you inherit latency, connectivity, privacy, and safety headaches.
+
+So when hardware researchers claim a 70% energy reduction for AI, the right reaction isn’t “cool chip.” The right reaction is: **does this move the needle for robots?**
+
+A new result from the University of Cambridge suggests it might.
+
+In April 2026, a Cambridge-led team reported a hafnium-oxide (HfO2) memristor device designed to behave like a “synapse” for neuromorphic computing. The key claim is not just lower energy, but *repeatability*: stable analog switching without the chaos that has historically haunted memristors.
+
+If it scales, this is the kind of hardware progress that can turn “robot brains” from research demos into deployable products.
+
+## Quick refresher: why today’s AI hardware wastes so much energy
+
+Most modern AI accelerators still have a fundamental architectural split:
+
+1. **Compute units** (where math happens)
+2. **Memory** (where weights/activations live)
+
+Even if the chip is fast, a huge amount of energy is spent **moving data** back and forth. This is often described as the “memory wall” or the Von Neumann bottleneck.
+
+For robotics, it gets worse:
+
+- Models are increasingly multimodal (vision + language + proprioception + tactile).
+- Control loops want low-latency, high-frequency decisions.
+- Battery life and thermal headroom are non-negotiable.
+
+So the dream is “in-memory computing”: store and process in the same place, like biology does.
+
+## What is a memristor (and why does it keep coming up)?
+
+A **memristor** is a two-terminal device whose resistance depends on its history. In neuromorphic terms, that’s useful because synapses are essentially *adjustable connection strengths*.
+
+A memristor array can, in principle, do two things well:
+
+- **Store weights** as analog conductance values
+- **Compute efficiently** using physics (e.g., matrix-vector multiply through Ohm’s law and Kirchhoff’s laws)
+
+This is why memristors show up anytime someone talks about “brain-like” AI hardware.
+
+But memristors have had a nasty practical problem: many designs switch by forming tiny conductive filaments inside an oxide. Those filaments can be **stochastic** (random-ish), which makes device behavior inconsistent.
+
+Inconsistent devices mean inconsistent computation. And inconsistent computation is a deal-breaker if you want reliable models.
+
+## The Cambridge twist: switch at the interface, not via random filaments
+
+The Cambridge team’s approach targets that core issue.
+
+Instead of relying on filament formation and rupture, they engineered a hafnium-oxide thin film that changes resistance through a more controlled interface mechanism.
+
+### The mechanism (high level)
+
+By adding **strontium and titanium** and using a **two-step growth process**, the researchers formed tiny electronic gates (p-n junction-like heterointerfaces) inside the device stack. Rather than a filament randomly appearing somewhere in the oxide, the device’s resistance changes by **shifting the energy barrier at an interface**.
+
+This matters because **interfaces are engineerable**. Random filaments are not.
+
+The result is what memristor researchers have been chasing for years:
+
+- Better cycle-to-cycle repeatability
+- Better device-to-device uniformity
+- Many stable intermediate conductance states (good for analog weights)
+
+The team reports that the switching currents are roughly **a million times lower** than some conventional oxide-based memristors, and that neuromorphic systems could cut energy use by **~70%** by combining memory and processing in-place.
+
+Sources:
+
+- University of Cambridge press release (with DOI): https://www.cam.ac.uk/research/news/new-computer-chip-material-inspired-by-the-human-brain-could-slash-ai-energy-use
+- ScienceDaily summary: https://www.sciencedaily.com/releases/2026/04/260422044633.htm
+- SemiEngineering overview + reference list: https://semiengineering.com/research-bits-apr-6/
+
+## Why uniformity is the killer feature (not the headline energy number)
+
+Energy numbers are seductive. But for robotics, the **more important claim** might be uniformity.
+
+A robot is a closed-loop system.
+
+If your “synapses” drift unpredictably, then:
+
+- Your policy changes subtly over time.
+- Safety margins shrink.
+- Long-horizon behavior becomes harder to validate.
+
+This is why many neuromorphic hardware announcements don’t cross the chasm. They show exciting physics, then fall apart when you try to build large arrays with predictable behavior.
+
+Switching at an engineered interface is a direct attack on that reliability gap.
+
+## What the reported performance implies
+
+From the reporting and secondary coverage, a few performance notes stand out:
+
+- **Ultra-low switching currents** (reported at or below 10^-8 A in coverage)
+- **Many distinct conductance levels** (hundreds), which is what you need for analog weight resolution
+- **Endurance** beyond tens of thousands of switching cycles
+- **Synapse-like behavior** including spike-timing dependent plasticity (STDP)
+
+In plain English: the device isn’t just a fancy memory cell. It’s being tuned to behave like a hardware synapse for learning/inference.
+
+That said, the articles also mention retention on the order of about a day in some tests. Retention requirements can vary depending on whether the device is used for “weights” vs. short-lived states, but in any deployable system you’d want robust retention and calibration strategies.
+
+## What this could change for robots (if it scales)
+
+Let’s translate this into robotics outcomes.
+
+### 1) Smaller, cooler, longer-lasting edge intelligence
+
+If neuromorphic in-memory computing actually reduces energy meaningfully, robots get:
+
+- longer runtime per charge
+- smaller batteries for the same runtime
+- less cooling hardware
+- lighter platforms
+
+For humanoids, battery weight is existential. For drones, it is literally flight time. For mobile manipulators, it is cost and safety.
+
+### 2) More autonomy without cloud dependence
+
+A big reason teams push compute offboard is power and thermal limitations.
+
+If you can run more of the stack on-device, you improve:
+
+- latency
+- reliability under poor connectivity
+- privacy (no streaming video to the cloud)
+- safety (fewer network-induced failure modes)
+
+### 3) “Always-on” perception and anomaly detection
+
+Many robots use duty cycling because always-on perception is expensive.
+
+Lower-power neuromorphic hardware could support:
+
+- continuous vision + audio monitoring
+- lightweight prediction and anomaly triggers
+- event-driven compute (compute only when something changes)
+
+This is a very brain-like pattern: perception is constant, heavy reasoning is occasional.
+
+### 4) A new path for on-robot learning
+
+On-robot adaptation is attractive (personalized behaviors, new environments) but dangerous (catastrophic failures).
+
+Neuromorphic hardware that supports stable analog updates might enable safer, bounded forms of adaptation:
+
+- small fine-tuning at the edge
+- learning in limited submodules
+- continual learning for perception rather than control
+
+Even if robots don’t do full policy learning on-device, local adaptation of perception and world models is a huge win.
+
+## The biggest obstacle: 700°C fabrication temperature
+
+Here’s the part that keeps this grounded in reality: the reported process requires around **700°C**, above standard CMOS manufacturing tolerances.
+
+This is not a small footnote. It’s the difference between:
+
+- “interesting paper”
+- “can be built at scale on real silicon”
+
+The good news is the materials are described as CMOS-compatible, and the team explicitly calls out temperature reduction as the next step.
+
+In other words, the real question is not whether the physics works. It’s whether the process can be pulled into the industrial pipeline without breaking yield and cost.
+
+## How this fits into the 2026 robotics trendline
+
+This work is part of a broader pattern in 2026:
+
+- Models are getting more capable, but also heavier.
+- Robotics is shifting from “better policies” to “better stacks.”
+- Hardware efficiency is becoming a first-class constraint.
+
+We’ve already seen “robot foundation model” talk converge on the same painful constraints:
+
+- energy
+- latency
+- determinism
+- reliability
+
+Neuromorphic memristor work is one of the few hardware directions that directly targets the data-movement tax at the heart of modern AI compute.
+
+## What I’d watch next (before getting too excited)
+
+If you’re tracking whether this becomes real robotics infrastructure, watch for:
+
+1. **Array-scale demos** (not single-device results)
+2. **Calibration + drift management** over weeks/months, not hours/days
+3. **Manufacturing temperature reduction** toward CMOS-friendly processes
+4. **Benchmarking on real workloads** (vision backbones, sensor fusion, control inference)
+5. **System-level comparisons**: battery life, thermal performance, latency vs. conventional accelerators
+
+The “robot impact” is never decided by a single device. It’s decided by the system that can be manufactured, integrated, validated, and shipped.
+
+## Bottom line
+
+If this interface-switching hafnium-oxide memristor approach scales, it’s exactly the kind of breakthrough that could make **low-power, always-on robot intelligence** much more practical.
+
+The headline energy savings (~70%) is compelling, but the deeper value is the push toward **uniform, stable analog synapses**—the missing ingredient that has kept memristor neuromorphic hardware from being trustworthy.
+
+Right now, the fabrication temperature is the big gate. If the team can bring it down and demonstrate large, reliable arrays, this could become part of the hardware foundation for the next wave of edge robotics.
+
+### References
+
+- B. Bakhit et al., “HfO2-based memristive synapses with asymmetrically extended p-n heterointerfaces for highly energy-efficient neuromorphic hardware,” *Science Advances* (2026). https://doi.org/10.1126/sciadv.aec2324
+- University of Cambridge: https://www.cam.ac.uk/research/news/new-computer-chip-material-inspired-by-the-human-brain-could-slash-ai-energy-use
+- ScienceDaily: https://www.sciencedaily.com/releases/2026/04/260422044633.htm
+- SemiEngineering coverage: https://semiengineering.com/research-bits-apr-6/


### PR DESCRIPTION
## Summary\nDeep-dive news analysis on Cambridge's interface-switching HfO2 memristor synapse and what it means for low-power edge AI in robotics.\n\n## Topic\nNeuromorphic in-memory computing, memristors, and energy-efficient robot intelligence.\n\n## Keywords\nmemristor, neuromorphic computing, hafnium oxide, edge AI, robotics hardware, energy efficiency