### PR TITLE
Daily post: NVIDIA GR00T N1.6 + LeRobot (2026-05-03)

### DIFF
--- a/content/blog/nvidia-groot-n1-6-lerobot-isaac-lab-arena-osmo.md
+++ b/content/blog/nvidia-groot-n1-6-lerobot-isaac-lab-arena-osmo.md
@@ -1,0 +1,160 @@
+---
+title: "NVIDIA GR00T N1.6 + LeRobot: The Open-Source Stack That Makes Robot Policies Shippable"
+slug: "nvidia-groot-n1-6-lerobot-isaac-lab-arena-osmo"
+date: "2026-05-03"
+author: "bob-jiang"
+category: "tutorials"
+tags: ["robotics", "physical AI", "GR00T", "LeRobot", "Isaac Lab-Arena", "VLA models", "simulation", "synthetic data"]
+excerpt: "NVIDIA’s GR00T N1.6 and Isaac Lab-Arena landing inside Hugging Face’s LeRobot is less about new model weights and more about finally standardizing evaluation and workflows for robot learning."
+featured: true
+published: true
+seo:
+  title: "NVIDIA GR00T N1.6 + LeRobot: The Open Robotics Stack"
+  description: "A practical breakdown of NVIDIA GR00T N1.6, Isaac Lab-Arena, Cosmos world models and OSMO — and why integration with Hugging Face LeRobot matters for shipping robot policies."
+  keywords: ["NVIDIA GR00T N1.6", "Hugging Face LeRobot", "Isaac Lab-Arena", "robot policy evaluation", "VLA model", "Cosmos world models", "OSMO robotics"]
+---
+
+## Introduction: the real bottleneck isn’t “a better model”
+
+Robot learning has a familiar pattern:
+
+- A paper drops with impressive demos.
+- Everyone clones the repo.
+- A few labs replicate results.
+- Almost nobody can **compare** methods fairly or **ship** a policy into a real robot with confidence.
+
+That’s not because people are lazy. It’s because end-to-end robotics is still fragmented:
+
+- data formats differ
+- evaluation tasks differ
+- sim stacks differ
+- orchestration is custom glue
+
+NVIDIA’s latest move — putting **Isaac open models and tooling directly into Hugging Face’s LeRobot** — is aimed at the unsexy part: *standardization*. The headline model is **Isaac GR00T N1.6**, but the bigger story is the stack around it: **Cosmos world models**, **Isaac Lab-Arena** for benchmarking, and **OSMO** for running the pipeline.
+
+Sources:
+- NVIDIA newsroom announcement (CES 2026): https://nvidianews.nvidia.com/news/nvidia-releases-new-physical-ai-models-as-global-partners-unveil-next-generation-robots
+- Isaac GR00T repo: https://github.com/NVIDIA/Isaac-GR00T
+- Cosmos world models (Transfer/Predict/Reason): https://github.com/nvidia-cosmos
+- Isaac Lab-Arena overview: https://developer.nvidia.com/isaac/lab-arena
+
+## What is GR00T N1.6 (and what it isn’t)
+
+NVIDIA describes **Isaac GR00T N1.6** as an open *reasoning* **vision-language-action (VLA)** model designed for humanoid robots. The key claims:
+
+- it’s built for **full-body control** (not just grippers)
+- it leverages **Cosmos Reason** (a reasoning VLM) for stronger contextual understanding
+- it’s distributed as an **open model** on Hugging Face / GitHub to reduce pretraining burden
+
+What it isn’t:
+
+- a magic “general humanoid brain” you can drop into any robot and call it done
+- a replacement for good systems engineering (safety, timing, control loops, calibration)
+
+The realistic way to think about GR00T is: *a strong prior* (policy + reasoning scaffold) that you fine-tune or adapt — and then you must prove it works reliably.
+
+## Why LeRobot matters: opinionated plumbing is a feature
+
+Hugging Face’s LeRobot has been turning into the “PyTorch of robotics data + policies”: a common place to store datasets, train policies, and share baselines.
+
+When NVIDIA says “GR00T N models and Isaac Lab-Arena are now available in the LeRobot library,” the practical consequences are:
+
+- **Fewer bespoke pipelines.** If your training loop is roughly standardized, you can focus on the robot.
+- **Better baseline comparisons.** You can benchmark “my method vs your method” without a month of reimplementation.
+- **Faster onboarding.** New engineers don’t need to learn 5 incompatible robotics ML conventions.
+
+This is exactly the pattern that accelerated progress in vision and NLP: shared datasets + shared tooling + shared eval.
+
+## Cosmos world models: the synthetic data engine behind the curtain
+
+Robot data is expensive. Really expensive.
+
+NVIDIA’s Cosmos lineup is meant to reduce that cost by generating and evaluating in simulation with more physical grounding:
+
+- **Cosmos Transfer 2.5** — physically based synthetic data generation
+- **Cosmos Predict 2.5** — predictive world modeling for simulation evaluation
+- **Cosmos Reason 2** — a reasoning vision-language model for physical-world understanding
+
+In a clean workflow, you use Cosmos to:
+
+1. generate diverse scenes / interactions
+2. train or fine-tune policies
+3. stress-test with long-tail scenarios
+4. only then spend precious real-robot hours
+
+The important nuance: synthetic data doesn’t remove sim-to-real. It **reshapes it**. You still need reality checks — but you can arrive with a policy that has seen more variation than your lab could ever stage.
+
+## Isaac Lab-Arena: benchmarking as a first-class product
+
+Most robotics “evaluation” today is:
+
+- run a few tasks
+- hand-pick the nicest videos
+- maybe report success rate on a custom setup
+
+That’s not evaluation. That’s marketing.
+
+**Isaac Lab-Arena** is NVIDIA’s attempt to make large-scale policy evaluation and benchmarking an actual system:
+
+- standardized tasks
+- connection to established benchmarks (NVIDIA mentions Libero and RoboCasa)
+- scalable simulation runs
+- collaboration-friendly structure
+
+If LeRobot becomes the training commons, Isaac Lab-Arena is the **test harness** that keeps everyone honest.
+
+My take: this is the biggest win. Models will keep changing; rigorous eval infrastructure compounds.
+
+## OSMO: orchestration is the hidden tax you keep paying
+
+Even with good models and good eval, teams lose weeks to:
+
+- running synthetic data jobs
+- scheduling training runs
+- software-in-the-loop tests
+- tracking artifacts across workstation + cloud
+
+NVIDIA **OSMO** is positioned as a cloud-native orchestration layer so you can define and run workflows across mixed compute.
+
+If you’ve ever built a robotics ML pipeline, you know why this matters: the “glue code” becomes the product.
+
+## A practical “shippable policy” workflow (what this stack enables)
+
+Here’s the workflow NVIDIA is implicitly pushing — and it’s a good one:
+
+1. **Start from an open prior**
+   - use GR00T N1.6 (humanoid) or other Isaac open policies
+
+2. **Fine-tune in a shared framework**
+   - use LeRobot conventions for datasets and training scripts
+
+3. **Generate coverage, not just more data**
+   - use Cosmos to create hard cases (occlusions, lighting, contact variations)
+
+4. **Benchmark before you touch hardware**
+   - use Isaac Lab-Arena to measure performance on standardized tasks
+
+5. **Orchestrate repeatably**
+   - run jobs via OSMO so training/eval is reproducible
+
+6. **Then do real-robot validation**
+   - focus real testing on what simulation can’t guarantee: calibration drift, tactile quirks, timing issues, safety constraints
+
+That pipeline is how robotics stops being “cool demos” and becomes something you can iterate like software.
+
+## What to watch next (if you’re building robots)
+
+If you want to judge whether this actually changes the game, watch for:
+
+- **Reference baselines in LeRobot** using GR00T + Isaac Lab-Arena that others can reproduce
+- **Task coverage**: are the benchmarks broad enough to predict real-world failures?
+- **Sim fidelity vs throughput tradeoffs**: teams will still pick speed over realism unless failures become expensive
+- **Hardware interoperability stories** (e.g., Reachy 2 + Jetson Thor claims) turning into repeatable developer docs
+
+## Bottom line
+
+GR00T N1.6 is interesting, but the point isn’t a new humanoid VLA weight file.
+
+The point is: robotics is finally getting the missing middle layer — *shared training + shared evaluation + shared orchestration* — that turns robot learning from a craft into an engineering discipline.
+
+If this integration with LeRobot sticks, we’ll look back at it the way we look at ImageNet or COCO in vision: not perfect, but catalytic.


### PR DESCRIPTION
## Summary\nExplains why NVIDIA’s GR00T N1.6 + Isaac Lab-Arena integration into Hugging Face LeRobot matters: standardized training, benchmarking, and orchestration for shipping robot policies.\n\n## Topic\nGR00T N1.6, Cosmos world models, Isaac Lab-Arena, OSMO, and the LeRobot ecosystem.\n\n## Keywords\nGR00T N1.6, LeRobot, Isaac Lab-Arena, Cosmos, OSMO, robot policy evaluation