### PR TITLE
Daily post: RoboCasa365 Explained (2026-05-04)

### DIFF
--- a/content/blog/robocasa365-household-mobile-manipulation-benchmark.md
+++ b/content/blog/robocasa365-household-mobile-manipulation-benchmark.md
@@ -1,0 +1,321 @@
+---
+title: "RoboCasa365 Explained: The Kitchen-Scale Benchmark Pushing Generalist Robots Beyond Tabletop"
+slug: "robocasa365-household-mobile-manipulation-benchmark"
+date: "2026-05-04"
+author: "bob-jiang"
+category: "tutorials"
+tags: ["robotics", "benchmarks", "simulation", "imitation learning", "mobile manipulation", "datasets", "VLA", "generalist robots"]
+excerpt: "RoboCasa365 is a large-scale household mobile manipulation benchmark with 365 tasks across 2,500 kitchens and 2,000+ hours of demos—here is what it enables, what it measures, and how to use it well."
+featured: true
+published: true
+seo:
+  title: "RoboCasa365 Explained: Benchmarking Generalist Home Robots"
+  description: "A practical breakdown of RoboCasa365 (ICLR 2026): 365 household tasks, 2,500 kitchens, 2,000+ hours of demos, and what it means for training and evaluating generalist robot policies."
+  keywords: ["RoboCasa365", "RoboCasa", "robot benchmark", "household robotics simulation", "mobile manipulation dataset"]
+---
+
+## Introduction
+
+“Generalist robots” are the dream: one policy that can **clean up a kitchen, unload a dishwasher, fetch an object from a drawer, and recover from mistakes**, not just execute a single scripted skill in a lab.
+
+The uncomfortable truth is that progress here is hard to measure.
+
+Real-world robot evaluation is expensive, noisy, and rarely reproducible across labs. Meanwhile, many popular robotics benchmarks still skew toward **tabletop manipulation**, where the robot is bolted to a table and the “environment” is a small set of props placed in a tidy workspace.
+
+That is exactly the gap **RoboCasa365** is trying to close.
+
+In an ICLR 2026 paper from UT Austin and NVIDIA Research, the authors introduce **RoboCasa365: a large-scale simulation benchmark for household mobile manipulation** with:
+
+- **365 everyday tasks**
+- **2,500 diverse kitchen environments**
+- **612+ hours of human demonstrations**
+- **1,615+ hours of synthetic demonstrations** (generated with MimicGen)
+
+Source: arXiv / OpenReview (RoboCasa365)  
+- https://arxiv.org/abs/2603.04356  
+- https://openreview.net/forum?id=tQJYKwc3n4
+
+This post breaks down what RoboCasa365 is, why it matters, what it actually tests, and how to use benchmarks like this without fooling yourself.
+
+## Why tabletop benchmarks are no longer enough
+
+Tabletop settings are popular for good reasons: they are easy to simulate, easy to instrument, and easier to reproduce across labs. But a household robot that only works on a tabletop is basically a robot that can only function in a carefully staged demo.
+
+Household work is different:
+
+1. **Space is part of the problem.** The robot must navigate to the right location, pick a good base position, and keep itself out of trouble.
+2. **Tasks are longer-horizon.** “Make coffee” isn’t one grasp; it’s a chain of subgoals with branching failure modes.
+3. **The world is cluttered and variable.** Kitchens differ wildly in layout, object placement, lighting, textures, and occlusions.
+4. **Memory and semantics matter.** You need to open the correct cabinet, choose the right container, or remember where you put something.
+
+If your benchmark does not pressure-test these dimensions, you can get misleadingly high success rates that collapse in the real world.
+
+## What RoboCasa365 is (in one paragraph)
+
+**RoboCasa365** is a simulation framework and benchmark built on the RoboCasa platform (Nasiriany et al., 2024) designed to train and evaluate generalist robot policies in **room-scale, kitchen-like environments**. It defines **365 tasks** spanning **60 kitchen activities**, provides **thousands of distinct kitchen scenes**, and includes **large-scale demonstration data** (human + synthetic) to support different learning settings: massively multi-task training, robot foundation model training, and lifelong learning.
+
+Source: arXiv abstract and HTML version  
+- https://arxiv.org/abs/2603.04356  
+- https://arxiv.org/html/2603.04356v1
+
+## What “365 tasks” actually implies
+
+A common failure mode in benchmarking is to inflate the task count with trivial variations (“pick up the red block” vs “pick up the blue block”). RoboCasa365 is explicitly positioned as broader than that: tasks are drawn from **60 kitchen activities** and include elements like:
+
+- **Manipulation:** open/close, grasp, place, pour-like sequences, handle objects in containers
+- **Semantic reasoning:** choose the correct object among distractors, interact with category-level targets
+- **Long-horizon planning:** multi-step sequences where earlier mistakes compound
+- **Memory-dependent tasks:** actions that require tracking state across time (for example, after moving objects around)
+
+The key idea is not “more tasks for the sake of it,” but enough coverage to:
+
+- stress generalization,
+- expose brittleness,
+- and make it harder to overfit to a narrow distribution.
+
+## The 2,500 kitchens: why environment diversity matters
+
+Many simulation benchmarks randomize object positions in a fixed scene. RoboCasa365 goes further by using **2,500 unique kitchen environments** modeled from real kitchens in the US (according to the paper’s introduction), which implies variation in:
+
+- layouts (islands, galley kitchens, U-shapes)
+- cabinet and drawer placement
+- object categories and clutter patterns
+- visual appearance, textures, and lighting
+
+Why is this a big deal?
+
+Because the “generalization” you care about in household robotics often looks like:
+
+- **new geometry** (different handle placements, different reachable volumes)
+- **new occlusions** (objects are partially hidden behind others)
+- **new backgrounds** (vision models lean on shortcuts)
+
+A benchmark that contains real structural diversity can reveal whether your policy learned a robust skill or memorized a handful of visual motifs.
+
+## The dataset: 600+ hours human + 1600+ hours synthetic
+
+RoboCasa365 combines:
+
+- **612 hours** of human demonstration data
+- **1,615 hours** of synthetic demonstrations generated with **MimicGen**
+
+Source: arXiv HTML version  
+- https://arxiv.org/html/2603.04356v1
+
+This is worth unpacking, because “synthetic demos” can mean wildly different things.
+
+### What synthetic demonstrations are good for
+
+Synthetic demonstration generation can:
+
+- expand coverage of rare task variants,
+- increase the number of examples per task,
+- and reduce the human collection burden.
+
+In practice, synthetic demos often improve **breadth** faster than they improve **quality**.
+
+You can think of it like this:
+
+- Human demos are high-quality “anchors” that define the task distribution.
+- Synthetic demos are a scaling tool that helps you explore more of the combinatorial space.
+
+### The risk: synthetic bias
+
+If synthetic demos are produced by a simulator policy with particular blind spots, those blind spots can become “baked into” the dataset.
+
+A robust benchmark should let you measure whether:
+
+- your policy generalizes beyond the generator,
+- and whether improvements are real or just “getting better at the synthetic teacher.”
+
+## What RoboCasa365 enables (three evaluation settings)
+
+One of the strongest aspects of RoboCasa365 is that it frames benchmarking across **multiple learning regimes**, not just “train on tasks, test on tasks.” The paper explicitly calls out three settings:
+
+1. **Massively multi-task training**
+2. **Foundation model training**
+3. **Lifelong learning**
+
+Source: arXiv abstract / OpenReview TL;DR  
+- https://arxiv.org/abs/2603.04356  
+- https://openreview.net/forum?id=tQJYKwc3n4
+
+Let’s translate what each of these means in practical terms.
+
+### 1) Massively multi-task training
+
+This is the “classic” benchmark setting, but scaled up:
+
+- train one policy on many tasks,
+- evaluate across held-out environments and task variations,
+- measure aggregate success, plus per-task breakdowns.
+
+The big question this setting answers is:
+
+If I add more tasks and more environments, do I get a policy that actually becomes more general… or does it plateau and forget?
+
+### 2) Foundation model training
+
+“Robot foundation models” usually imply some combination of:
+
+- large-scale imitation learning,
+- language conditioning,
+- multi-modal observations,
+- and architectures that can absorb diverse datasets.
+
+A simulation benchmark like RoboCasa365 can be used to:
+
+- pretrain a generalist policy,
+- stress-test scaling laws (data scale vs performance),
+- and evaluate how architecture choices behave under distribution shift.
+
+The important subtlety: “foundation model” is not a guarantee of generalization. A benchmark is valuable if it can cleanly separate:
+
+- models that look good at training time
+- from models that keep competence when you change the kitchen, the objects, and the task compositions.
+
+### 3) Lifelong learning
+
+Lifelong learning asks a harder question:
+
+Can a robot learn new tasks over time **without catastrophically forgetting** old ones?
+
+Household environments are naturally lifelong:
+
+- new devices show up
+- cabinets reorganize
+- the user’s habits change
+
+Benchmarks that support lifelong settings allow you to measure:
+
+- forward transfer (do earlier skills help later ones?)
+- backward transfer (does new learning improve old tasks?)
+- forgetting curves (how quickly old skills degrade)
+
+## How to read results from benchmarks like this (without getting tricked)
+
+Large benchmarks are not magical. They can still mislead you if you read them like a leaderboard.
+
+Here are the main traps and how to avoid them.
+
+### Trap 1: average success hides failure modes
+
+A single average success rate can hide the fact that:
+
+- the policy is great at simple “fetch/put” tasks,
+- but terrible at anything that needs long-horizon planning,
+- or collapses when navigation is required.
+
+The right way to evaluate is to slice performance by:
+
+- horizon length
+- manipulation complexity
+- environment shift magnitude
+- memory requirements
+
+If your method only moves the easy tasks, it is not a generalist breakthrough.
+
+### Trap 2: training-test leakage through environment templates
+
+Even with 2,500 kitchens, you can accidentally leak structure if:
+
+- training and test share scene generation templates,
+- object assets repeat with identical textures,
+- or the distribution shift is too mild.
+
+When using RoboCasa365 (or any benchmark), pressure-test generalization by holding out:
+
+- entire kitchen styles
+- sets of object categories
+- and combinations of tasks (compositional splits)
+
+### Trap 3: sim success does not equal real-world deployability
+
+Simulation is crucial, but real robots care about things simulators often approximate:
+
+- contact dynamics fidelity
+- perception noise
+- actuator delays and torque limits
+- failures like slipping, jamming, and partial grasps
+
+A strong workflow is:
+
+1. use simulation to iterate quickly,
+2. validate on a small but carefully designed real-world suite,
+3. feed real failures back into sim via domain randomization and targeted asset upgrades.
+
+## Practical guide: how to use RoboCasa365 in your own research
+
+Even if you are not contributing to the benchmark, you can use it to make your own work more credible.
+
+### Choose an evaluation story before you train
+
+Decide what claim you want to support:
+
+- “Our method scales better with task diversity”
+- “Our representation generalizes across kitchen layouts”
+- “Our approach reduces forgetting in lifelong training”
+
+Then design splits and ablations around that claim.
+
+### Use explicit generalization splits
+
+Avoid only reporting “IID test” results. Instead, report at least one of:
+
+- new kitchens (layout/style holdout)
+- new object instances (asset holdout)
+- new task compositions (subgoal recombination)
+
+### Report data efficiency, not just peak performance
+
+Large datasets can hide inefficiency.
+
+Good plots include:
+
+- success vs number of demos
+- success vs number of kitchens
+- success vs number of tasks
+
+If two methods tie at 2,000 hours but one reaches the same score at 300 hours, that is the better method.
+
+### Treat synthetic demos as a variable
+
+Because RoboCasa365 explicitly mixes human and synthetic demonstrations, you can study:
+
+- human-only baseline
+- synthetic-only baseline
+- blended training at multiple ratios
+
+This is one of the most actionable research levers in the benchmark.
+
+## Why this matters for the next generation of home robots
+
+The household robot conversation is often dominated by two extremes:
+
+- glossy humanoid demos that hide failure recovery
+- narrow industrial automation that avoids the messy home entirely
+
+Benchmarks like RoboCasa365 push the field toward a middle path:
+
+- measure generalization in a realistic domain,
+- scale data and task diversity systematically,
+- and evaluate under settings that look like “real life” (multi-task and continual).
+
+It will not instantly produce a robot that cleans your kitchen.
+
+But it does something more valuable: it makes it harder for us to fool ourselves about progress.
+
+## Key takeaways
+
+- **RoboCasa365 is a kitchen-scale simulation benchmark** with **365 tasks** across **2,500 kitchens** and **2,000+ hours** of demonstrations.
+- It targets the hard parts of household robotics: **mobile manipulation, long-horizon planning, semantics, and memory**.
+- It supports three realistic evaluation regimes: **massively multi-task learning, foundation model training, and lifelong learning**.
+- The benchmark’s value is not only in scale, but in enabling **systematic generalization analysis**.
+
+If you are building robot learning systems in 2026, you should be evaluating on benchmarks like this—or at least borrowing their philosophy: **diversity, reproducibility, and splits that actually test the claim you are making**.
+
+## References
+
+- RoboCasa365 paper (arXiv): https://arxiv.org/abs/2603.04356
+- RoboCasa365 (OpenReview / ICLR 2026 submission): https://openreview.net/forum?id=tQJYKwc3n4
+- RoboCasa365 HTML (experimental): https://arxiv.org/html/2603.04356v1


### PR DESCRIPTION
## Summary
A practical breakdown of RoboCasa365 (ICLR 2026): what the benchmark includes (365 tasks, 2,500 kitchens, 2,000+ hours of demos), why it matters, and how to interpret results without getting tricked by averages.

## Category
Tutorials

## Source
https://arxiv.org/abs/2603.04356