### PR TITLE
Daily post: China 15th Five-Year Plan puts robotics at the center (2026-05-08)

### DIFF
--- a/content/blog/china-15th-five-year-plan-embodied-ai-robotics-strategy-2026.md
+++ b/content/blog/china-15th-five-year-plan-embodied-ai-robotics-strategy-2026.md
@@ -1,0 +1,222 @@
+---
+title: "China's 15th Five-Year Plan Puts AI-Powered Robots at the Center: What It Means for Embodied AI"
+slug: "china-15th-five-year-plan-embodied-ai-robotics-strategy-2026"
+date: "2026-05-08"
+author: "bob-jiang"
+category: "news"
+tags: ["robotics", "China", "embodied AI", "industrial robots", "humanoid robots", "automation", "manufacturing"]
+excerpt: "China's 2026–2030 Five-Year Plan elevates robotics from automation to AI-native embodied intelligence, reshaping supply chains, adoption timelines, and global competition."
+featured: true
+published: true
+seo:
+  title: "China 15th Five-Year Plan: Embodied AI and Robotics"
+  description: "China's 15th Five-Year Plan (2026–2030) makes AI-powered robots a national priority. Learn what changes for industrial robots, humanoids, and embodied AI stacks."
+  keywords: ["China robotics strategy", "15th Five-Year Plan robotics", "embodied AI", "industrial robots China", "humanoid robots China"]
+---
+
+## Introduction: A plan that turns robotics into national infrastructure
+
+On May 5, 2026, the International Federation of Robotics (IFR) summarized what many people in robotics have felt for a while but rarely see stated so directly: China is treating AI-powered robots as core national infrastructure under its 15th Five-Year Plan (2026–2030). The headline is not “more robots in factories” (China already leads there). The shift is from classic industrial automation toward **high-end, intelligent robotics integrated with AI**, aligned across thousands of regional and sector plans.
+
+That framing matters because it implies two things at once:
+
+1. **Industrial robots will keep scaling** (because they work, right now).
+2. **Humanoid robots will be “commercialized later”** (because the hard parts are still hard).
+
+In this post, we will unpack what the IFR announcement says, connect it to the broader embodied AI analysis from MERICS, and translate it into practical implications for builders and investors: timelines, bottlenecks, and where competitive advantage will actually come from.
+
+**Primary sources used:**
+- IFR press release: *China Makes AI-powered Robots Core of National Strategy* (May 5, 2026)
+- MERICS report: *Embodied AI: China’s ambitious path to transform its robotics industry* (Apr 30, 2026)
+- arXiv survey: *World Model for Robot Learning: A Comprehensive Survey* (May 2026)
+
+## The baseline reality: China is already the global industrial robotics center
+
+The most important context is that China is not starting from zero. According to IFR, China’s manufacturing sector has an operational stock of **around 2 million industrial robots**, roughly **4.5×** the installed base of Japan, and **54% of annual global industrial robot installations** happen inside China.
+
+This matters because industrial robots are not “tech demos.” They are deployment at scale. They create:
+
+- An installed base that produces massive operational data
+- A workforce of integrators and automation engineers
+- A supplier ecosystem for actuators, drives, sensors, and safety hardware
+- A strong ROI playbook across electronics, metal, machinery, and automotive
+
+If you want to turn “AI in the physical world” into GDP, that is the platform.
+
+## What the plan is actually signaling: from automation to embodied intelligence
+
+IFR describes the 15th Five-Year Plan as shifting focus from “traditional industrial automation” to **“high-end, intelligent robotics integrated with artificial intelligence.”** This is basically the policy version of “robots need a brain, not just a PLC.”
+
+MERICS adds nuance: Beijing’s strategy is not just about factory productivity. It is part of a broader techno-solutionist approach where AI is expected to integrate deeply into the real economy and into governance systems. In that worldview, embodied AI becomes a lever for:
+
+- Addressing labor shortages and rising labor costs
+- Keeping industrial value chains domestic
+- Diffusing AI across society via “intelligent terminals”
+- Potentially creating military and domestic security advantages through robotics and unmanned systems
+
+From a robotics product perspective, this is a push to move from “robot as a machine” to “robot as an AI-native agent.”
+
+## Humanoid robots: why the spectacle is not the same as the capability
+
+IFR calls out something refreshingly blunt. China has been showcasing humanoids globally via dance performances and public running events, but the “actual capabilities in real-world production scenarios are currently limited to demonstrators or pilot projects.”
+
+This is the key distinction:
+
+- **Stage performance** proves locomotion robustness, choreography control, and system integration under controlled conditions.
+- **Factory work** requires long-hour uptime, tight cycle times, precise manipulation, safe human interaction, fault recovery, and repeatability across messy edge cases.
+
+Even when you see a humanoid “doing a task,” it can still be a prototype supported by:
+
+- Teleoperation or heavy human-in-the-loop supervision
+- A highly curated environment
+- Task simplification (fixtures, special tools, slow speeds)
+
+MERICS reaches similar conclusions, noting that current humanoids “still lack precision and dexterity” and remain far from “fully autonomous machines capable of perceiving and responding in real time in the physical world.”
+
+### The underrated point: platform and embodied AI are not the same company
+
+IFR also notes that “the humanoid platform itself and the embodied AI are not necessarily developed at the same time and by the same market players.”
+
+That is a big deal.
+
+It implies a stack split similar to smartphones:
+
+- A hardware/platform layer (bodies, actuators, power, thermal, safety)
+- An embodied intelligence layer (perception, world modeling, planning, control)
+- A deployment layer (integration, monitoring, fleet ops, support)
+
+If those layers separate cleanly, the winners might not be the most charismatic humanoid vendor. They might be whoever owns the data flywheel and the software stack that generalizes.
+
+## Industrial robots vs humanoids: “form follows function” is still undefeated
+
+IFR contrasts humanoids with traditional industrial robots using a simple idea: **form follows function**.
+
+Industrial robots often have fewer joints, are built for a narrow job, and therefore can be controlled with simpler, faster, and more reliable schemes. In high-speed, precision-driven manufacturing, specialization is a feature, not a bug.
+
+Humanoids, on the other hand, trade specialization for generality:
+
+- More degrees of freedom
+- More complicated contact and balance dynamics
+- Higher sensing and compute requirements
+- More failure modes
+
+This means the near-term likely outcome is not “humanoids replace industrial robots,” but rather:
+
+1. Industrial robots continue to dominate high-throughput tasks.
+2. Mobile manipulation expands in logistics and flexible workcells.
+3. Humanoids appear first in constrained pilots where human-like reach, mobility, or interface compatibility matters.
+
+IFR also states that mass adoption of humanoids as universal factory helpers or household assistants will not happen in the near to medium term. Under the plan, commercialization is expected “towards the end” of the 2026–2030 period.
+
+## China’s domestic advantage: deployment scale and a fast-localizing supply chain
+
+If you want a simple explanation for why China is dangerous in robotics, it is this:
+
+- The country has the world’s largest demand pool for industrial automation.
+- That creates huge volumes of deployment and operational learning.
+- That enables fast iteration and scaling.
+
+IFR provides a datapoint that supports MERICS’ broader thesis: the share of local suppliers in domestic industrial robot installations increased from **30% (2020) to 57% (2024)**.
+
+In other words, China is not only buying robots. It is building the domestic champions that sell them.
+
+MERICS adds that the EV supply chain accelerates robotics manufacturing because key components overlap:
+
+- Batteries
+- Cameras and lidar
+- Power electronics
+- Manufacturing know-how for high-volume mechatronics
+
+If you squint, humanoids can look like “EVs with legs”: power, sensors, compute, actuators, and supply chain discipline.
+
+## The embodied AI stack: hardware is not enough, software is the bottleneck
+
+The policy framing is “AI-powered robots,” but what makes a robot truly AI-native is not a bigger GPU. It is a software stack that can:
+
+- Perceive reliably in the real world
+- Predict how the world will change under actions
+- Plan long-horizon behavior under uncertainty
+- Recover from failure without human babysitting
+
+This is where the concept of **world models** becomes more than academic hype.
+
+A recent arXiv survey on world models for robot learning defines world models as predictive representations of how environments evolve under actions, supporting planning, simulation, evaluation, and data generation. The survey argues that purely reactive Vision-Language-Action policies struggle in long-horizon tasks, and that explicit predictive structure is a path to better robustness and reasoning.
+
+For a national robotics strategy, this matters because world models and predictive simulators are the multiplier:
+
+- They reduce dependence on expensive real-world data collection
+- They improve safety and validation before deployment
+- They enable post-training and policy improvement at scale
+
+In practical terms: the “intelligence” that will differentiate winners in 2026–2030 will look like a combination of:
+
+- Foundation policy models (VLA, diffusion policies, behavior models)
+- World models for planning and evaluation
+- High-quality simulation and synthetic data pipelines
+- Fleet learning loops from deployed robots
+
+## The timeline that most people get wrong
+
+A useful way to interpret IFR’s adoption timeline is to separate **capability milestones** from **commercialization milestones**.
+
+### Industrial robots: 5–10 years of AI integration
+
+IFR expects wide adoption of AI with traditional industrial robotics over the next five to ten years. That suggests a path like:
+
+- Smarter perception and inspection
+- Faster setup and reprogramming via natural language or demonstration
+- Better anomaly detection and predictive maintenance
+- Increased use of flexible automation in electronics and machinery
+
+These are incremental wins that compound quickly because the baseline is already profitable.
+
+### Humanoids: commercialization late in the plan period
+
+The plan suggests humanoids reach commercialization closer to 2029–2030. That implies the next few years are still dominated by:
+
+- Pilot deployments
+- Standardization and safety work
+- Cost-down efforts
+- Data and training infrastructure buildup
+
+MERICS notes that for commercial viability, costs likely need to drop by at least half. Cost down is not just “make motors cheaper.” It is also:
+
+- Fewer sensors through better modeling
+- Lower compute needs through more efficient policies
+- Higher uptime through reliability engineering
+- Easier integration and support
+
+## What this means for the rest of the world (and for Europe in particular)
+
+MERICS warns that Europe could face a repeat of the EV story: strong incumbents, slower scaling, and then a sudden competitive shock once China’s supply chain and deployment loop hit a threshold.
+
+The competitive mechanism is not mysterious:
+
+- State support + large domestic market
+- Aggressive localization of components
+- Massive iteration speed through deployment density
+
+If you are building robotics outside China, the response is not panic. It is focus. Compete where you have real leverage:
+
+- Differentiated hardware (high-end components, safety-certified systems)
+- Trusted software stacks and certifications for regulated industries
+- High-reliability deployment and support models
+- Specialized applications with deep domain knowledge
+
+## The bottom line: the “robot race” is shifting from demos to systems
+
+China’s 15th Five-Year Plan is not just a political signal. It is a coordination tool. It tells capital, provinces, universities, and manufacturers: **build the embodied AI stack, and scale it through deployment.**
+
+But it also implicitly acknowledges reality:
+
+- Humanoids are not ready for mass adoption today.
+- Industrial robots remain the backbone of manufacturing automation.
+- The winners will be the teams that make robots reliable, cost-effective, and scalable as systems.
+
+If you are watching humanoid videos and thinking that is the whole story, you are missing the point. The real story is the boring one: supply chains, deployment density, software reliability, and data flywheels.
+
+## References
+
+- International Federation of Robotics (IFR). "China Makes AI-powered Robots Core of National Strategy" (May 5, 2026). https://ifr.org/ifr-press-releases/news/china-makes-ai-powered-robots-core-of-national-strategy
+- MERICS. "Embodied AI: China’s ambitious path to transform its robotics industry" (Apr 30, 2026). https://merics.org/en/report/embodied-ai-chinas-ambitious-path-transform-its-robotics-industry
+- Li, G. et al. "World Model for Robot Learning: A Comprehensive Survey" (May 2026). https://arxiv.org/abs/2605.00080


### PR DESCRIPTION
## Summary
This post breaks down IFR’s announcement that China’s 15th Five-Year Plan (2026–2030) makes AI-powered robots a national priority, and what that implies for industrial robots vs humanoids, embodied AI stacks, and commercialization timelines.

## Category
news

## Sources
- IFR press release (May 5, 2026)
- MERICS report (Apr 30, 2026)
- arXiv world-model survey (May 2026)