### PR TITLE
Daily post: Humanoid Robots in 2026: From Demos to Deployments (2026-05-09)

### DIFF
--- a/content/blog/humanoid-robots-2026-from-demos-to-deployments.md
+++ b/content/blog/humanoid-robots-2026-from-demos-to-deployments.md
@@ -1,0 +1,213 @@
+---
+title: "Humanoid Robots in 2026: The Shift From Demos to Deployments (and Why Engineering Now Wins)"
+slug: "humanoid-robots-2026-from-demos-to-deployments"
+date: "2026-05-09"
+author: "bob-jiang"
+category: "case-studies"
+tags: ["humanoid robots", "Physical AI", "deployment", "manufacturing", "simulation", "robotics", "RaaS"]
+excerpt: "Humanoid robotics is moving from flashy demos to measurable productivity, and the winners are becoming the teams that can ship reliable systems at scale."
+featured: true
+published: true
+seo:
+  title: "Humanoid Robots 2026: From Demos to Deployments"
+  description: "In 2026, humanoid robots are being judged less by stunts and more by uptime, safety, and scalable deployment. Here is what changed and what to track."
+  keywords: ["humanoid robots 2026", "humanoid robot deployment", "Physical AI", "robot simulation", "RaaS humanoid robots"]
+---
+
+## Introduction: the hype phase is ending
+
+Humanoid robots have spent the last decade as internet celebrities: backflips, dance routines, and controlled-lab manipulation clips. Those demos mattered because they proved *feasibility*. But in 2026, feasibility is table stakes.
+
+What is changing now is the evaluation standard. The most revealing “benchmark” isn’t a curated video — it’s whether a robot can operate in a messy environment, day after day, without constant babysitting.
+
+Two recent signals make that shift obvious:
+
+1. **Humanoids are being judged in longer, more system-level public trials**, like the 2026 Beijing humanoid half-marathon, which pushed teams to demonstrate navigation, endurance, stability, and operational robustness rather than a single isolated skill. IDC’s recap explicitly frames the event as an indicator of commercialization readiness, not just technical spectacle. Source: IDC analysis (May 2026) <https://www.idc.com/resource-center/blog/humanoid-robotics-commercialization-2026/>
+
+2. **The “Physical AI stack” is getting more complete and more open**, which accelerates iteration cycles and makes deployment a software-and-integration race. NVIDIA’s National Robotics Week 2026 overview ties together simulation (Isaac Sim), training (Isaac Lab), world models (Cosmos), and an open physics engine (Newton 1.0) as part of a cloud-to-robot workflow. Source: NVIDIA (Apr/May 2026) <https://blogs.nvidia.com/blog/national-robotics-week-2026/>
+
+This post breaks down what “demos to deployments” really means, what changed technologically, and how to think about the next 12–24 months if you’re building, buying, or investing in humanoids.
+
+## The new success metric: reliability beats capability
+
+A demo is optimized for **peak capability**. Deployment is constrained by **worst-case reliability**.
+
+When a humanoid robot is introduced into a factory, a warehouse, or a public venue, the question quickly becomes:
+
+- Can it complete tasks **repeatably**?
+- Can it recover when things go wrong?
+- Can it operate safely around humans?
+- Can it be monitored and maintained without a PhD onsite?
+
+IDC highlights this exact transition in evaluation: teams are moving beyond “basic mobility” and toward **system-level validation** — perception, decision-making, and execution working together with stability in dynamic environments. <https://www.idc.com/resource-center/blog/humanoid-robotics-commercialization-2026/>
+
+That’s why 2026 feels different. The industry is being forced to obsess over the unglamorous parts:
+
+- power and thermal management
+- sensor fusion under real noise
+- failure modes and safe fallback behaviors
+- maintainability and field service
+- fleet operations and monitoring
+
+Those are engineering problems — not just model problems.
+
+## Why public “marathon-style” trials matter more than you think
+
+Humanoid contests can look like marketing, but they function as a brutal integration test.
+
+IDC notes that this year’s event expanded participation (100+ teams) and that a significant portion of teams (IDC cites **38%**) adopted **fully autonomous navigation**, reflecting a shift toward robots operating reliably in complex environments. <https://www.idc.com/resource-center/blog/humanoid-robotics-commercialization-2026/>
+
+A long-duration trial (like a half-marathon) forces tradeoffs that mirror real deployments:
+
+### 1) Energy and thermal are not optional
+
+IDC calls out **hot-swappable batteries and liquid cooling** as critical enablers for endurance and uptime. Those are exactly the kinds of subsystems that separate “cool prototype” from “fieldable machine.”
+
+### 2) Robust localization and mapping becomes a product feature
+
+A robot that runs well in a lab can fail outdoors (lighting changes, textureless surfaces, moving obstacles). IDC describes multimodal perception stacks that combine **LiDAR, vision, IMUs, positioning, real-time mapping**, enabling stable operation over uneven terrain and dynamic obstacles.
+
+### 3) Recovery behavior is the hidden bar
+
+In deployment, you don’t need perfect control; you need **graceful degradation**. When a joint overheats, a camera drops frames, or the floor is slightly wet, the robot should slow down, re-plan, and stay safe.
+
+These tests reward not just the “best policy,” but the best system design.
+
+## The enabling shift: a more complete Physical AI toolchain
+
+If you want to ship humanoids at scale, you need to iterate quickly — and safely. The real acceleration in 2026 is that the tooling stack is becoming something teams can actually standardize on.
+
+NVIDIA’s National Robotics Week 2026 summary is a good snapshot of what’s converging:
+
+- **Simulation and synthetic data** workflows that are closer to real sensor physics.
+- **World models** (Cosmos) to generate varied data and improve generalization.
+- **A modern open physics engine** (Newton 1.0) aimed at contact-rich manipulation and locomotion.
+- A broader ecosystem of Isaac tools (Isaac Sim, Isaac Lab, evaluation frameworks).
+
+Source: <https://blogs.nvidia.com/blog/national-robotics-week-2026/>
+
+### What this changes in practice
+
+A few years ago, many teams trained policies in a simulator that was “good enough,” and then spent months discovering the mismatch to reality. In 2026, the pipeline is shifting toward:
+
+1. **high-fidelity simulation for rapid iteration**
+2. **massive synthetic variation** (lighting, geometry, materials, clutter)
+3. **smaller, targeted real-world data collection**
+4. **continuous post-training and evaluation loops**
+
+That is not magic — it’s a faster feedback loop.
+
+And faster loops are what let engineering teams close the gap from “works once” to “works every shift.”
+
+## The real bottleneck is integration, not intelligence
+
+When people talk about humanoids, they often focus on the “brain” — vision-language-action models, imitation learning, reinforcement learning, and so on.
+
+But deployments fail for boring reasons:
+
+- the gripper slips on packaging with different friction
+- calibration drifts across temperature
+- a safety controller triggers false positives and halts the robot
+- the robot can’t be diagnosed remotely
+- the battery swap process is inconsistent
+
+IDC explicitly highlights **hardware-software co-optimization** and engineering capability as the key determinant of commercial viability. <https://www.idc.com/resource-center/blog/humanoid-robotics-commercialization-2026/>
+
+This is why 2026 is becoming an “engineering wins” year: the model improvements are still happening, but the differentiator is increasingly your ability to ship a stable integrated system.
+
+## The commercialization pattern: from demo scenarios to productivity scenarios
+
+IDC describes early deployments (2025) being concentrated in **performances, education, data collection, guided tours** — environments where “novelty + interaction” provides value even if reliability isn’t perfect. <https://www.idc.com/resource-center/blog/humanoid-robotics-commercialization-2026/>
+
+That’s a normal adoption curve. The key is what comes next.
+
+### Stage 1: demonstration value
+
+- brand marketing
+- “innovation theater”
+- customer engagement in retail
+- data collection for training
+
+### Stage 2: assisted productivity
+
+- teleoperation as fallback
+- semi-structured tasks like internal logistics
+- human-in-the-loop systems where the robot does 80% and a person handles edge cases
+
+### Stage 3: scalable productivity
+
+- repeatable tasks with measurable KPIs
+- fleet management and maintenance playbooks
+- economics that beat alternatives (humans, fixed automation, or outsourcing)
+
+Most humanoid programs are currently transitioning between stages 1 and 2.
+
+The winners of 2026–2027 will be the teams that can cross into stage 3.
+
+## What to measure if you are serious about deployments
+
+If you want to cut through hype, measure these:
+
+### 1) Uptime and mean time to recovery
+
+Not just “hours on a battery,” but how often the robot pauses, needs reset, or gets stuck.
+
+### 2) Task success rate under variation
+
+Can the robot handle different box sizes, reflectivity, lighting, clutter, and “unexpected but normal” conditions?
+
+### 3) Safety envelope and false positives
+
+A robot that stops constantly because safety is too conservative isn’t useful. A robot that never stops is dangerous. The goal is a tuned envelope with auditable behavior.
+
+### 4) Operational cost per task
+
+This is where RaaS models matter.
+
+IDC notes growing adoption of **Robot-as-a-Service (RaaS)** models (leasing/subscription) as a way to reduce adoption friction and accelerate penetration. <https://www.idc.com/resource-center/blog/humanoid-robotics-commercialization-2026/>
+
+For customers, RaaS shifts the question from “Can we justify a large capex bet?” to “Does this subscription save money or create enough value?”
+
+### 5) Maintainability and swap time
+
+How fast can you replace a limb, a sensor, a battery? Field service is where many robotics startups die.
+
+## The role of simulation is expanding: it is becoming the “factory” for skills
+
+The biggest strategic change is that **skills are becoming software artifacts** that can be tested, versioned, rolled back, and deployed fleet-wide.
+
+NVIDIA’s stack framing is essentially a statement that simulation + data generation + evaluation is becoming a standard development workflow for robots, similar to how CI/CD became standard for software. <https://blogs.nvidia.com/blog/national-robotics-week-2026/>
+
+That matters because it flips the economics:
+
+- Instead of training every robot individually, you can train a policy centrally.
+- Instead of collecting every edge case in the real world, you can generate large classes of variations synthetically.
+- Instead of “pray and deploy,” you can regression test in sim.
+
+The practical implication is that the “best deployment teams” will look less like pure research labs and more like full-stack engineering organizations.
+
+## Predictions for the next 12–24 months
+
+Based on the shift IDC describes (commercialization acceleration, system-level evaluation) and the tooling direction NVIDIA highlights (more complete stacks), here are the changes I expect to dominate:
+
+1. **Competition will shift from single-robot demos to fleet metrics.** Customers will demand evidence that a vendor can support 10, 100, then 1,000 robots.
+
+2. **Data flywheels will become deployment flywheels.** Real-world operations will generate the hard cases that improve reliability, which increases deployments, which generates more data.
+
+3. **Energy, thermal, and maintainability will become major differentiators.** Not glamorous, but unavoidable.
+
+4. **RaaS and managed service models will expand.** Many customers will prefer buying outcomes (pallets moved, parts delivered) instead of buying robots.
+
+5. **Open tooling will lower the barrier — and increase the pressure.** If the development stack is increasingly accessible, vendors can no longer hide behind “secret sauce” for basic functionality. Execution becomes everything.
+
+## Conclusion: the “humanoid era” starts when nobody is filming
+
+The true “humanoid moment” won’t be the next viral clip. It will be the day a factory manager stops thinking of the humanoid as a prototype and starts treating it like another piece of equipment — measured by uptime, cost, and throughput.
+
+2026 is where that shift is becoming visible. Events like long-duration public trials emphasize system-level robustness. Toolchains are maturing, making iteration faster. And commercialization is increasingly about integration and engineering discipline.
+
+If you’re building humanoids: obsess over the boring metrics.
+
+If you’re buying humanoids: demand deployment evidence.
+
+And if you’re watching the space: pay attention to who can ship, not who can stunt.


### PR DESCRIPTION
## Summary
A 2026-focused look at why humanoid robotics is shifting from flashy demos to measurable deployment metrics (uptime, autonomy, maintainability) — and how modern simulation + world-model tooling is accelerating iteration.

## Sources
- NVIDIA National Robotics Week 2026 overview: https://blogs.nvidia.com/blog/national-robotics-week-2026/
- IDC analysis on the 2026 humanoid half-marathon and commercialization: https://www.idc.com/resource-center/blog/humanoid-robotics-commercialization-2026/

## Post
- File: content/blog/humanoid-robots-2026-from-demos-to-deployments.md
- Category: case-studies
- Word count: ~1660

## Keywords
humanoid robots, deployment, Physical AI, simulation, RaaS