### PR TITLE
Daily post: Samsung and Meta bet on humanoids (2026-05-10)

### DIFF
--- a/content/blog/samsung-meta-humanoid-robots-body-of-ai-2026.md
+++ b/content/blog/samsung-meta-humanoid-robots-body-of-ai-2026.md
@@ -1,0 +1,209 @@
+---
+title: "Samsung and Meta Bet on Humanoid Robots: Why the 'Body of AI' Race Is Starting Now (2026)"
+slug: "samsung-meta-humanoid-robots-body-of-ai-2026"
+date: "2026-05-10"
+author: "bob-jiang"
+category: "news"
+tags: ["humanoid robots", "Samsung", "Meta", "embodied AI", "manufacturing", "robotics economics", "industrial automation"]
+excerpt: "Samsung and Meta are both moving into humanoid robotics—this post explains why 2026 is a commercialization inflection point, and why real deployments will be narrower (and more valuable) than the hype suggests."
+featured: true
+published: true
+seo:
+  title: "Samsung and Meta Humanoid Robots: Why the Body of AI Race Starts in 2026"
+  description: "Samsung and Meta are entering humanoid robotics. Learn what this signals for embodied AI, which jobs are actually viable first, and what metrics will decide winners."
+  keywords: ["Samsung humanoid robot", "Meta humanoid robotics", "embodied AI", "humanoid robot commercialization", "robotics market"]
+---
+
+## The “AI race” is leaving the screen
+
+For the last few years, the AI race looked like a software story: model sizes, benchmarks, token costs, and who could ship the best copilots.
+
+That phase is still accelerating—but something else is happening in parallel: the center of gravity is shifting from **code** to **capability**. The important question is no longer “Can a model reason?” It’s “Can an AI system **reliably do physical work** in the messy real world?”
+
+A recent report in *Korea JoongAng Daily* framed it bluntly: AI is moving into the physical world, and humanoid robots are becoming the next “front line of industrial power.” It called this the race to occupy the **“body of AI.”**
+
+Two moves make the shift feel real:
+
+- **Samsung** is expected to unveil a humanoid robot as early as the second half of 2026, with an initial focus on manufacturing environments.
+- **Meta** has been acquiring robotics AI capability and moving key people into its AI org, indicating it wants a serious position in robot intelligence—not just AR/VR.
+
+These are not hobby projects. They’re the kind of strategic bets that only happen when big players believe a new platform is about to become economically meaningful.
+
+This post breaks down what’s actually going on—and how to separate **near-term reality** from humanoid hype.
+
+## What Samsung and Meta are signaling
+
+### Samsung: start with factories, then expand
+
+Samsung has been unusually explicit about the sequencing:
+
+1. **Industrial humanoids first** (manufacturing-focused humanoids and dual-arm robots)
+2. **Home and retail later** (after the technology matures)
+
+That roadmap is exactly what you’d expect from a company that understands production engineering. Factories give you:
+
+- controlled environments
+- repeatable tasks
+- clear ROI calculation
+- existing maintenance and safety procedures
+
+It’s the least romantic, most profitable place to start.
+
+Samsung also said it plans to “internalize key robotics components” and build customized parts optimized for its own robots—classic vertical-integration thinking. In humanoids, cost and reliability are a function of boring subsystems: actuators, geartrains, sensors, thermal design, power electronics, and manufacturing yield.
+
+### Meta: the software-first humanoid play
+
+Meta’s likely play is different. It doesn’t own factories in the same way Samsung does. It’s historically been a platform + ecosystem company.
+
+From the same *JoongAng Daily* piece: Meta acquired a robotics AI startup working on a foundational model for humanoid robots, and the team is joining Meta’s AI division.
+
+In other words: Meta wants the “brain” layer for robots—models and tooling that can generalize physical skills. That maps to what Meta does well:
+
+- large-scale AI research
+- data tooling and infrastructure
+- consumer platforms and distribution
+
+If you believe robot intelligence becomes a foundation-model problem (a *world model + action* stack), then Meta doesn’t need to build the best hardware to matter. It needs to become the place where robot developers build and fine-tune the best *policies*.
+
+## Why 2026 feels like a turning point (and why that’s dangerous)
+
+A common narrative in robotics is:
+
+> “We’ve solved walking. Humanoids are here. Now the market is massive.”
+
+There’s a kernel of truth: modern biped systems are better than they were five years ago. But “walking works” is not the same as “humanoid labor works.”
+
+The *JoongAng Daily* report points to two drivers that analysts often cite:
+
+- the cost per unit could fall sharply over the next five years
+- labor shortages make automation more attractive
+
+Those may be true. But the real gating factor is still the same: **reliability at scale**.
+
+Here’s the key insight from a pragmatic market analysis published by CleanTechnica: humanoid market sizing tends to start from total labor (a huge number) instead of starting from the **physics of work**. A better lens is a two-axis reality check:
+
+- **Dexterity burden:** how hard it is to manipulate objects and environments
+- **Human-proximity safety burden:** how hard it is to operate near humans without unacceptable risk
+
+When you map jobs onto those axes, the “near-term serviceable market” collapses into a smaller set of environments where both burdens are manageable.
+
+That’s not pessimism. It’s focus.
+
+## The uncomfortable truth: manipulation is the real boss fight
+
+Humanoid robots look like they’re about locomotion because locomotion is visible in demos.
+
+But manipulation is where deployments live or die.
+
+- Picking up rigid boxes in a structured layout is relatively low variance.
+- Handling cables, bags, dishes, clothing, or any deformable clutter is high variance.
+
+Every additional degree of freedom (hands), every sensor, every controller, and every skill library increases capability—but also increases **failure modes**.
+
+The CleanTechnica piece uses a simple thought experiment: if you have many subsystems at 99% reliability, the combined system reliability can drop quickly as interactions multiply. Real systems aren’t modeled that way, but the direction is right: **complexity compounds.**
+
+This is why companies that talk about “humanoids in every home” are not wrong in the long run—but they’re skipping the hard middle.
+
+## The first real humanoid markets won’t be glamorous
+
+The markets that become real first are the ones where you can constrain the world.
+
+### 1) Structured logistics (warehouses)
+
+Warehouses are attractive because:
+
+- objects can be standardized (totes, bins, cartons)
+- workflows repeat
+- safety can be engineered (clear zones, speed limits)
+
+A robot that can do one or two tasks with high uptime can be economically compelling.
+
+### 2) Manufacturing support (not “do everything”)
+
+Samsung’s stated direction—manufacturing-focused humanoids—fits this.
+
+Think of tasks like:
+
+- kitting and line-side replenishment
+- moving materials between stations
+- simple machine tending
+
+Humanoids won’t beat specialized automation on throughput. They win when the plant wants **flexibility** without retooling a line.
+
+### 3) Remote or hazardous inspection
+
+Human-proximity safety burden is lower when humans aren’t nearby, even if environments are messy.
+
+This is where a humanoid form factor *can* make sense: human infrastructure is built for humans (stairs, ladders, valves). But the market is narrower than “replace all labor.”
+
+## Why China’s strategy matters to this story
+
+The International Federation of Robotics (IFR) published a May 2026 note on China’s **15th Five-Year Plan (2026–2030)**, describing a pivot: robotics is being placed at the heart of China’s modern industrial system, with AI pushed toward physical applications.
+
+Two points are worth highlighting:
+
+1. China is already dominant in industrial robot deployment scale.
+2. The plan frames humanoid commercialization as later in the period, while wide adoption of AI with *traditional* industrial robotics is expected over the next 5–10 years.
+
+That matters because it’s a reality check from an industry body: **industrial robots remain the backbone** of high-speed precision manufacturing, and humanoids are not automatically superior.
+
+The IFR also points out something subtle: staged humanoid showcases (dancing, running) do not imply readiness for production. The humanoid platform and “embodied AI” do not always advance together or even come from the same companies.
+
+This should shape how you interpret Samsung/Meta moves: they are positioning themselves for the platform shift, but they still have to win the grind of deployments.
+
+## The “body of AI” is a full stack problem
+
+If humanoids become a real platform, the winners won’t be decided by one thing.
+
+You need the full stack:
+
+- **hardware:** actuators, power, thermal management, sensor quality, manufacturability
+- **control:** balance, whole-body control, impedance/force control, compliance
+- **perception:** robust scene understanding in changing lighting and clutter
+- **policy learning:** skill acquisition, generalization, adaptation, recovery behavior
+- **safety:** constraint enforcement, monitoring, fail-safe behaviors, certification pathways
+- **operations:** fleet monitoring, maintenance, spare parts, human escalation loops
+
+Samsung has obvious strength in hardware + manufacturing.
+
+Meta has obvious strength in models + data + tooling.
+
+The most likely outcome is not one company “wins humanoids.” It’s an ecosystem: some companies dominate hardware platforms, others dominate model stacks, and integrators deliver vertical solutions.
+
+## What metrics will decide whether this is real
+
+If you want to know whether humanoids are truly commercializing (not just demoing), look for deployment metrics—not hype.
+
+From CleanTechnica’s framing, the evidence that changes the game looks like:
+
+- **tens of thousands of robot-hours** in production environments
+- **task success rates above 99%** for a defined workflow
+- **intervention rates below 1 per hour** (ideally far lower)
+- throughput comparisons vs humans and existing automation
+- maintenance costs expressed in **$ per operating hour**
+- safety incident and near-miss statistics
+- repeat orders after pilots
+
+If Samsung launches a manufacturing humanoid in H2 2026, the meaningful announcement won’t be “it can walk.” It will be “it ran X hours across Y factories, at Z intervention rate.”
+
+Similarly, the meaningful signal from Meta won’t be “we trained a big robot model.” It will be “our stack improved deployment metrics on real robots across multiple integrators.”
+
+## So… should you be excited?
+
+Yes—if you’re excited about **hard engineering turning into product**.
+
+But don’t buy the trillion-dollar narrative wholesale.
+
+Humanoids are not a single market; they’re a sequence of increasingly difficult markets along the dexterity and safety axes.
+
+The smartest companies in 2026 will do what Samsung is signaling: start where the world is structured enough to deliver ROI, then climb the ladder as the stack matures.
+
+The smartest AI labs will do what Meta is signaling: treat robot intelligence as a foundation-model problem, but stay brutally honest about real-world constraints.
+
+The race for the “body of AI” has started. Now we find out who can ship.
+
+## Sources
+
+- Korea JoongAng Daily: "Samsung, Meta want to make movement in the AI market with humanoid robots" (May 9, 2026) https://koreajoongangdaily.joins.com/news/2026-05-09/business/tech/Samsung-Meta-want-to-make-movement-in-the-AI-market-with-humanoid-robots/2586663
+- International Federation of Robotics (IFR): "China Makes AI-powered Robots Core of National Strategy" (May 5, 2026) https://ifr.org/ifr-press-releases/news/china-makes-ai-powered-robots-core-of-national-strategy
+- CleanTechnica: "The Humanoid Robot Market Is Smaller Than It Looks" (May 3, 2026) https://cleantechnica.com/2026/05/03/the-humanoid-robot-market-is-smaller-than-it-looks/


### PR DESCRIPTION
## Summary
Explains why Samsung and Meta are moving into humanoid robotics in 2026, what near-term markets are actually viable, and which deployment metrics will separate hype from reality.

## Category
news

## Sources
- Korea JoongAng Daily (May 9, 2026)
- IFR press release (May 5, 2026)
- CleanTechnica analysis (May 3, 2026)