### PR TITLE
Daily post: Meta + Samsung chase the body of AI (2026-05-11)

### DIFF
--- a/content/blog/meta-samsung-body-of-ai-humanoid-robots-2026.md
+++ b/content/blog/meta-samsung-body-of-ai-humanoid-robots-2026.md
@@ -1,0 +1,230 @@
+---
+title: "Meta + Samsung Chase the Body of AI: Why Humanoid Robots Are the Next Platform (2026)"
+slug: "meta-samsung-body-of-ai-humanoid-robots-2026"
+date: "2026-05-11"
+author: "bob-jiang"
+category: "news"
+tags: ["humanoid robots", "Meta", "Samsung", "physical AI", "robotics", "foundation models", "manufacturing", "embodied AI"]
+excerpt: "Meta is hiring for whole-body robot intelligence while Samsung signals industrial humanoids first—together they show why the next AI platform battle is happening in hardware, data, and deployment." 
+featured: true
+published: true
+seo:
+  title: "Meta and Samsung Bet on Humanoid Robots in 2026"
+  description: "Meta acquired Assured Robot Intelligence while Samsung outlined an industrial-humanoid roadmap. Here is what this signals for the race to build the body of AI."
+  keywords: ["Meta humanoid robots", "Samsung humanoid robot", "physical AI", "embodied AI", "humanoid foundation model", "industrial humanoid robots", "robot control models"]
+---
+
+## Introduction: the AI race is leaving the screen
+
+For the last few years, “the AI race” mostly meant model size, GPU clusters, and who could ship the best chat interface. That era is ending. The next competitive frontier is the **body of AI**: machines that can **sense, plan, and act** in the physical world.
+
+Two recent signals make this shift hard to ignore:
+
+- **Meta** acquired the humanoid-robotics startup **Assured Robot Intelligence (ARI)** and is moving the team into **Meta Superintelligence Labs**.
+- **Samsung** publicly discussed a roadmap that starts with **industrial humanoids and dual‑arm robots**, and then expands into home/retail once the technology matures.
+
+On the surface, these sound like “robotics is cool again” headlines. Underneath, they reveal something more strategic: the companies building the most useful AI models will increasingly need **physical feedback loops**—data and evaluation that only exist when an agent interacts with the real world.
+
+This article breaks down what Meta and Samsung are actually doing, why humanoids are an unusually attractive platform bet, and what the winners will look like by 2030.
+
+## What Meta bought (and what it implies)
+
+According to TechCrunch, Meta acquired **Assured Robot Intelligence (ARI)** for an undisclosed sum. Meta described ARI as working at “the frontier of robotic intelligence” to help robots **understand, predict, and adapt to human behaviors** in complex, dynamic environments.
+
+ARI’s team—including co‑founders **Lerrel Pinto** and **Xiaolong Wang**—is joining Meta’s AI unit, the **Superintelligence Labs** research division.
+
+From a product perspective, Meta has not promised a consumer humanoid robot. But the acquisition still matters for three reasons.
+
+### 1) Meta is prioritizing the “robot brain” over the robot body
+
+Meta’s core advantage is not industrial manufacturing. It is **AI research**, **compute**, and the ability to recruit top talent. ARI fits that profile: a team building **models for robot control and self‑learning**, i.e., the software stack that turns a general-purpose machine into a useful worker.
+
+If Meta succeeds, it could supply the “brains” that many robot manufacturers use—similar to how Android became the default smartphone OS for hardware vendors.
+
+### 2) Humanoids are a training environment, not just a product category
+
+The logic that keeps showing up inside top labs is simple:
+
+- If you want broadly capable intelligence, you need agents that can learn **cause and effect**.
+- The physical world is the most information‑dense place to learn cause and effect.
+- Robots provide the interface to that world.
+
+Even if Meta never sells a robot, humanoid robotics can still be a strategic asset for training and evaluation. It is difficult to know whether a model “understands” the world if it only predicts tokens. It is much easier to test understanding when the model has to **pick up a mug, open a cabinet, avoid a person, and recover from failure**.
+
+### 3) The long-term prize is a new platform layer
+
+A platform layer forms when many downstream products depend on a shared foundation: OS → app ecosystem → distribution.
+
+Humanoid robots could become that next platform. If Meta can provide:
+
+- a control foundation model,
+- a developer interface for skills and tools,
+- and a safety/monitoring layer,
+
+then a lot of hardware vendors could build around it.
+
+**Source:** TechCrunch, “Meta buys robotics startup to bolster its humanoid AI ambitions” (2026‑05‑01).
+
+## Samsung’s roadmap: industrial first, then consumer
+
+Korea JoongAng Daily reports that Samsung is expected to unveil a humanoid robot as early as the second half of this year, citing industry sources and analyst commentary.
+
+On an earnings call, Samsung described a roadmap that starts with:
+
+- **manufacturing-focused humanoids and dual‑arm robots** (semiconductor and display production lines are natural early targets),
+- followed later by **home and retail humanoids** once the technology matures.
+
+Samsung’s CFO emphasized two points that are especially telling:
+
+1. Samsung wants to **internalize key robotics components** and build capabilities to develop customized parts optimized for its own robots.
+2. Samsung may consider **strategic investments and acquisitions** to accelerate.
+
+In other words, Samsung is treating humanoids like a serious hardware program: components, supply chain, and manufacturing competence—not a demo.
+
+**Source:** Korea JoongAng Daily, “Samsung, Meta want to make movement in the AI market with humanoid robots” (2026‑05‑09).
+
+## Why humanoids, specifically?
+
+It is fair to ask: why are so many companies choosing humanoids rather than simpler robots?
+
+Humanoids are not the easiest path to automation. In many settings, specialized machines win. But humanoids have three properties that make them a uniquely powerful “platform bet.”
+
+### 1) They fit human spaces without rebuilding the world
+
+Factories, warehouses, homes, hospitals—these environments were built for **humans**. Doors, stairs, shelves, tools, carts, handles, workstations, personal protective equipment: all are standardized around a human body.
+
+A humanoid does not need every environment redesigned. It can, in principle, work with what already exists.
+
+This matters because the real bottleneck in automation is often not the robot; it is the **integration cost**. Any form factor that reduces integration cost is economically advantaged.
+
+### 2) They unify a lot of tasks under one body
+
+A mobile base plus two arms plus dexterous hands can do a very large set of tasks:
+
+- pick/place and kitting,
+- machine tending,
+- basic inspection and data capture,
+- packaging,
+- intra-facility errands,
+- and eventually light maintenance.
+
+This is crucial because many facilities are “death by a thousand micro‑tasks.” A specialized robot can solve one task, but the facility still needs people for the rest.
+
+Humanoids promise consolidation.
+
+### 3) They create a broader data flywheel
+
+If a robot’s body is general-purpose, the same control model can be reused across tasks and sites. That means the data you collect from one deployment can help others.
+
+For large companies, that’s the real opportunity:
+
+- Deploy a first wave of robots in a narrow setting.
+- Collect multimodal data: vision, force/torque, proprioception, human interaction signals, failures, recoveries.
+- Improve the model.
+- Redeploy the improved model.
+
+This loop is hard to replicate if your robots are highly specialized.
+
+## The real competition: data + reliability + unit economics
+
+The humanoid race will not be won by the most impressive demo video. The winners will be the teams that combine:
+
+1. **Data** (especially failure and recovery data)
+2. **Reliability engineering** (uptime, maintainability, safety cases)
+3. **Unit economics** (bill of materials, manufacturing yield, service cost)
+
+Meta and Samsung represent opposite halves of that triangle.
+
+- Meta: strong on model research and scaling; weaker on manufacturing.
+- Samsung: strong on manufacturing and components; historically weaker on frontier control models.
+
+That’s why both are making moves:
+
+- Meta buys ARI and concentrates robotics talent.
+- Samsung signals acquisitions and internal component development.
+
+## A practical view of “industrial humanoids first”
+
+Samsung’s plan to start in manufacturing is not just conservative—it is correct.
+
+Industrial environments offer advantages for early humanoid deployments:
+
+- tasks are more repetitive,
+- safety policies and training already exist,
+- there is a clear ROI model (labor substitution, throughput, quality),
+- and facilities can tolerate “robot lanes” and restricted zones.
+
+The typical arc looks like this:
+
+1. **Constrained tasks** with clear success criteria (move bins from A to B, simple kitting).
+2. **Assisted operation** with teleoperation fallback.
+3. **Autonomy with monitoring**, where the robot handles the common case and escalates edge cases.
+4. **Broader task coverage** as reliability and skill libraries grow.
+
+This is also where the data flywheel is easiest to bootstrap.
+
+## What Meta might do next
+
+If Meta is serious about the body of AI, there are a few plausible next steps.
+
+### Build a robotics “model + tools” platform
+
+A robot-control foundation model alone is not enough. Real deployments need:
+
+- skill/tool APIs,
+- structured task specifications,
+- perception and mapping modules,
+- safety constraints and policy monitors,
+- evaluation and logging pipelines,
+- and a workflow to incorporate new data.
+
+Meta is well positioned to build developer-facing tooling, because it has shipped large ecosystems before.
+
+### Partner with hardware makers (or quietly build its own)
+
+Meta could pursue an “Android for humanoids” approach by partnering with multiple hardware companies.
+
+Alternatively, it could build an internal reference platform (even if it is never sold) to control the full stack for research.
+
+Either way, ARI gives Meta a nucleus team to iterate faster.
+
+## What Samsung might do next
+
+Samsung’s best move is to avoid treating robotics as a standalone gadget category. Humanoids should be integrated into Samsung’s existing strengths:
+
+- manufacturing process engineering,
+- sensors and components,
+- edge compute,
+- and enterprise relationships.
+
+Two concrete advantages Samsung can exploit:
+
+1. **Component verticalization:** If you can reduce actuator, sensor, and compute cost, you can win on unit economics.
+2. **Manufacturing learning curves:** Samsung knows how to ship at scale. Humanoids will not be a “software-only” business.
+
+## Forecast: what the winners will look like by 2030
+
+By 2030, the “humanoid winners” probably share these traits:
+
+- They run a **general control model** that can be fine-tuned or adapted per site.
+- They have a **teleop + autonomy** hybrid strategy (robots learn from interventions).
+- They ship with a **safety case** that buyers trust (not just claims).
+- They have a **service and maintenance model** that keeps total cost predictable.
+- They own (or can access) a **large, continuously growing dataset** of real-world interaction.
+
+Meta and Samsung are making moves that align with this future—just from different angles.
+
+## Conclusion
+
+Humanoid robotics is not a side quest. It is increasingly the main route to building AI that can operate outside a chat window.
+
+Meta’s ARI acquisition is a clear signal: top AI labs want **whole-body control** and **self-learning** capabilities inside their org charts.
+
+Samsung’s roadmap is a different but equally important signal: major manufacturers believe industrial humanoids are approaching real commercialization—and they plan to compete through components, integration, and scale.
+
+If you want to understand the next decade of AI, stop asking only “what model is best?” and start asking “who can build the best loop between models and the real world?”
+
+### References
+
+- TechCrunch (2026-05-01): Meta buys robotics startup to bolster its humanoid AI ambitions — https://techcrunch.com/2026/05/01/meta-buys-robotics-startup-to-bolster-its-humanoid-ai-ambitions/
+- Korea JoongAng Daily (2026-05-09): Samsung, Meta want to make movement in the AI market with humanoid robots — https://koreajoongangdaily.joins.com/news/2026-05-09/business/tech/Samsung-Meta-want-to-make-movement-in-the-AI-market-with-humanoid-robots/2586663


### PR DESCRIPTION
## Summary\nA news/analysis post on Meta’s ARI acquisition and Samsung’s industrial-humanoid roadmap—why the next AI platform battle is happening in the physical world.\n\n## Keywords\nMeta, Samsung, humanoid robots, physical AI, embodied AI, foundation models\n\n## Post\ncontent/blog/meta-samsung-body-of-ai-humanoid-robots-2026.md