### PR TITLE
Daily post: EgoScale Explained (2026-05-14)

### DIFF
--- a/content/blog/egoscale-scaling-dexterous-manipulation-egocentric-human-data.md
+++ b/content/blog/egoscale-scaling-dexterous-manipulation-egocentric-human-data.md
@@ -1,0 +1,309 @@
+---
+title: "EgoScale Explained: The First Clear Scaling Law for Dexterous Robot Manipulation"
+slug: "egoscale-scaling-dexterous-manipulation-egocentric-human-data"
+date: "2026-05-14"
+author: "bob-jiang"
+category: "tutorials"
+tags: ["robotics", "dexterous manipulation", "VLA", "imitation learning", "egocentric video", "scaling laws", "embodied AI"]
+excerpt: "EgoScale shows that scaling egocentric human manipulation data creates predictable improvements in robot dexterity, including a log-linear scaling law that tracks real-robot success."
+featured: true
+published: true
+seo:
+  title: "EgoScale Explained: Scaling Laws for Robot Dexterity"
+  description: "EgoScale trains a vision-language-action policy on 20k+ hours of egocentric human video and finds a log-linear scaling law that predicts real-robot dexterous manipulation success."
+  keywords: ["EgoScale", "dexterous manipulation", "vision language action", "egocentric human data", "robot scaling law"]
+---
+
+## Why EgoScale matters (the short version)
+
+Robotics has been missing a reliable “compass” for progress.
+
+In language models, scaling laws tell you something simple but powerful: if you train longer on more data (and increase model capacity), performance improves in a fairly predictable way. In robotics, it has been much harder to get that kind of predictability because robots are expensive, environments vary, and benchmarks are noisy.
+
+**EgoScale** is exciting because it claims (and provides evidence for) something robotics has desperately needed:
+
+- **Human behavior is a scalable training signal** for robot dexterity.
+- **There is a measurable, log-linear scaling law** linking human-data scale to model loss.
+- That loss **correlates strongly with downstream real-robot performance**.
+
+In other words: if you want better robot hands, EgoScale suggests you can make real progress by scaling *human* data first — and you can forecast whether you are improving before you ever touch a robot.
+
+Primary source: the EgoScale paper on arXiv: https://arxiv.org/abs/2602.16710
+
+## The problem: dexterity is the “hard mode” of robotics
+
+If you’ve spent any time around robot manipulation, you already know the pattern:
+
+- Grasping a single rigid object is solvable.
+- Moving it around in a clean lab is mostly solvable.
+- Doing it **reliably**, for **long horizons**, with **tight contact dynamics**, with **many degrees of freedom** (DoF), and under **real-world variation** is where things get brutal.
+
+Dexterous hands make it worse in the best possible way: they unlock richer interaction, but they multiply the control and perception complexity.
+
+EgoScale targets this difficult zone:
+
+- **Dexterous manipulation**
+- **High-DoF hands (e.g., 22 DoF)**
+- **Long-horizon tasks**
+
+## The core idea: pretrain on egocentric human manipulation at scale
+
+The paper’s main bet is that **human manipulation video**, especially **egocentric (first-person)** footage with action labels, is one of the few data sources that can realistically be scaled to tens of thousands of hours.
+
+Robots cannot (yet) cheaply produce that much diverse interaction data in the real world.
+
+Humans can.
+
+EgoScale trains a **Vision-Language-Action (VLA)** policy on **20,854 hours** of action-labeled egocentric human video — which the authors describe as **more than 20× larger than prior efforts**.
+
+From the abstract:
+
+- “We train a Vision Language Action (VLA) model on over **20,854 hours** of action labeled egocentric human video…”
+- “…and uncover a **log linear scaling law** between human data scale and validation loss.”
+
+Source: https://arxiv.org/abs/2602.16710
+
+### Why egocentric matters
+
+Egocentric manipulation video has a few properties that make it unusually valuable:
+
+1. **The hands and objects are close and large in-frame** (better signal-to-noise for fine-grained contact).
+2. **The view is task-aligned** (what the actor sees is often what the agent needs).
+3. It captures the messy, practical, “how people actually do things” distribution.
+
+This is also a quiet acknowledgment: for dexterous tasks, third-person cameras are often not enough. You need the near-contact details.
+
+## The key claim: a scaling law that predicts real robot performance
+
+The headline result is not only “more data helps.” It is:
+
+- As you scale the amount of human data, the model’s validation loss decreases in a **log-linear** way.
+- That validation loss is not just an offline metric — it **strongly correlates with real-robot success**.
+
+If this holds up across groups and tasks, it changes how we build robotics systems.
+
+### What is a log-linear scaling law in plain English?
+
+A log-linear relationship means: when you plot performance (or loss) versus the **log of data size**, you get an approximately straight line.
+
+Practical interpretation:
+
+- Going from 1,000 to 2,000 hours helps.
+- Going from 10,000 to 20,000 hours also helps.
+- Each doubling gives you a somewhat consistent “bite” of improvement.
+
+This is the exact kind of curve the LLM world uses to budget training runs and decide whether a project is doomed early.
+
+### Why robotics scaling laws have been elusive
+
+Robotics learning curves usually break for reasons unrelated to data:
+
+- Sim-to-real mismatch
+- Sensor drift
+- Robot-specific quirks
+- Action space differences across embodiments
+- Small dataset sizes that make metrics unstable
+
+EgoScale is interesting because it tries to put the scaling law **upstream**:
+
+- Learn a general manipulation prior from humans
+- Transfer to robots later with minimal robot supervision
+
+That decouples (some of) the high-cost robot issues from the core representation learning.
+
+## The training recipe: two stages, not magic
+
+EgoScale is not claiming “human video alone solves dexterity.” It proposes a **simple two-stage transfer recipe**:
+
+1. **Large-scale human pretraining**
+2. **Lightweight aligned human-robot mid-training**
+
+From the abstract:
+
+- “Beyond scale, we introduce a simple two stage transfer recipe: large scale human pretraining followed by lightweight aligned human robot mid training.”
+
+Source: https://arxiv.org/abs/2602.16710
+
+This is important, because “human → robot” transfer typically fails unless you provide some bridge:
+
+- different kinematics
+- different sensory modalities
+- different action constraints
+
+The mid-training stage is where the model learns that bridge.
+
+## What kind of model is this? VLA in robotics terms
+
+“VLA” is becoming the default shape of modern robot foundation models:
+
+- **Vision**: what’s in the scene
+- **Language**: task goals, context, compositional instructions
+- **Action**: motor commands / trajectories / discretized tokens
+
+EgoScale fits into that lineage, but focuses specifically on **dexterous manipulation** rather than general mobile manipulation.
+
+Even if you ignore language, the core concept is still strong: learn a shared latent space that connects visual state to action sequences.
+
+## Results that matter: success rate gains and embodiment transfer
+
+The abstract highlights two practical outcomes:
+
+1. **A big success-rate improvement** versus no pretraining
+2. **Transfer across different robot hands (different DoF)**
+
+From the abstract:
+
+- “Our final policy improves average success rate by **54%** over a no pretraining baseline using a **22 DoF** dexterous robotic hand…”
+- “…and transfers effectively to robots with lower DoF hands, indicating that large scale human motion provides a reusable, embodiment agnostic motor prior.”
+
+Source: https://arxiv.org/abs/2602.16710
+
+### Why a 54% gain is meaningful (and what it is not)
+
+In robotics, “+54%” is usually either:
+
+- a genuine leap, or
+- a reminder that the baseline was weak.
+
+Without the full experimental context, you shouldn’t treat the number as a universal promise.
+
+But the direction is the key: **pretraining on human data can make the robot learning problem dramatically easier**.
+
+### Embodiment transfer is the real prize
+
+The words “embodiment agnostic motor prior” are doing a lot of work.
+
+If the policy truly learns reusable manipulation “chunks” that can be adapted to hands with fewer DoF, that suggests the representation is learning:
+
+- contact-relevant structure
+- object-centric action strategies
+- temporal coordination patterns
+
+This is the kind of transfer that robotics has traditionally struggled with.
+
+## A mental model: EgoScale as “robot pretraining without robots”
+
+It helps to think of EgoScale in the same framing as LLM pretraining:
+
+- LLMs pretrain on internet text (cheap, huge), then fine-tune on task data.
+- EgoScale pretrains on human manipulation video (cheap-ish, huge), then aligns to robot control.
+
+That analogy will never be perfect — actions are not words — but it’s close enough to guide system design.
+
+### Why this is strategically important for robotics companies
+
+If you believe EgoScale’s scaling law story, it suggests a playbook:
+
+1. Invest heavily in scalable human data collection (in-house, partners, or marketplaces)
+2. Build a strong pretraining pipeline (compute + representation)
+3. Use robots primarily for alignment, calibration, and evaluation (not for brute-force data generation)
+
+That is a very different cost curve than “collect robot data for everything.”
+
+## What you should be skeptical about
+
+Robotics hype is easy. Dexterity hype is even easier. A few things to watch:
+
+### 1) Action labels and data quality
+
+EgoScale relies on “action labeled egocentric human video.”
+
+- How are those actions represented?
+- How consistent are labels across people?
+- How noisy is the signal?
+
+Label noise may still be fine at large scale (LLMs survive noisy web text), but the action space is less forgiving.
+
+### 2) The “bridge” from human actions to robot actions
+
+Even with mid-training, the mapping from human hand motion to a specific robot hand is non-trivial.
+
+If the results depend on carefully curated alignment data, that can reduce the practical scalability.
+
+### 3) Evaluation breadth
+
+The paper claims correlation between validation loss and real-robot success.
+
+- How many tasks?
+- How many embodiments?
+- How diverse are objects and environments?
+
+Scaling laws can be real but brittle if evaluated too narrowly.
+
+## How this connects to the broader 2026 trend: scaling laws for physical AI
+
+If you zoom out, 2026 has been full of “physical AI” narratives:
+
+- VLA models for humanoids
+- world models for planning
+- synthetic data pipelines
+- better simulators
+
+What’s different about EgoScale is the explicit claim that **robotics may be entering a scaling-law era** — at least for dexterous manipulation.
+
+Even investor/industry commentary has started echoing this theme. For example, this May 2026 industry write-up highlights EgoScale as evidence that robotics foundation models may follow predictable scaling behavior similar to LLMs:
+
+- https://kraneshares.com/humanoid-robotics-in-2026-the-race-from-pilot-to-platform/
+
+(Use it as context, not as a primary technical reference.)
+
+## Practical takeaways (if you are building robot manipulation systems)
+
+Here is what EgoScale suggests you can do right now, even if you do not have an enormous robot fleet:
+
+### 1) Treat human data as a first-class asset
+
+If your roadmap includes dexterity, start thinking about:
+
+- egocentric capture rigs
+- action annotation (manual, semi-automated, or model-assisted)
+- privacy and consent pipelines
+- dataset versioning and taxonomy
+
+The “data engine” may matter more than your hand hardware.
+
+### 2) Invest in offline metrics that predict real-world success
+
+The most expensive mistake in robotics is training for weeks only to find out the policy fails in real contact.
+
+If validation loss can predict real success (even imperfectly), it becomes a **budgeting tool**.
+
+### 3) Separate representation learning from embodiment alignment
+
+Architect your pipeline so that:
+
+- pretraining produces reusable priors
+- embodiment alignment is modular and lightweight
+
+That makes it possible to reuse foundation components across products.
+
+## Where this likely goes next
+
+If EgoScale is a real signal and not a one-off, expect:
+
+- larger and more diverse egocentric datasets (not just kitchens)
+- better action representations (continuous, tokenized, diffusion-based)
+- standardized “human-to-robot alignment sets” for popular embodiments
+- scaling studies that include not just success rate, but robustness, safety, and recovery
+
+And if you are watching humanoids: better hands are a prerequisite for most “useful” humanoid work. EgoScale-like pretraining could end up being one of the key enablers.
+
+## Conclusion
+
+EgoScale is compelling because it takes a messy, expensive robotics problem (dexterous manipulation) and tries to make progress feel **predictable** again.
+
+The central message is simple:
+
+- Scale human manipulation data.
+- Use a VLA policy to learn a transferable motor prior.
+- Expect improvements that follow a scaling law.
+- Use lightweight robot alignment to cash that value out on real hardware.
+
+If the scaling-law-to-real-robot correlation holds across more tasks and embodiments, this is the kind of result that can shift an entire field’s strategy.
+
+---
+
+### References
+
+- EgoScale paper (arXiv): https://arxiv.org/abs/2602.16710
+- Industry context (May 2026): https://kraneshares.com/humanoid-robotics-in-2026-the-race-from-pilot-to-platform/


### PR DESCRIPTION
## Summary
This post explains the EgoScale paper and why its log-linear scaling law for egocentric human manipulation data is a big deal for dexterous robot learning.

## Topic
Dexterous manipulation pretraining with 20k+ hours of egocentric human data, and how offline loss can predict real-robot performance.

## Keywords
EgoScale, dexterous manipulation, VLA, egocentric video, scaling laws