### PR TITLE
Daily post: EgoScale Explained (2026-05-16)

### DIFF
--- a/content/blog/egoscale-scaling-egocentric-human-video-dexterous-manipulation.md
+++ b/content/blog/egoscale-scaling-egocentric-human-video-dexterous-manipulation.md
@@ -1,0 +1,299 @@
+---
+title: "EgoScale Explained: Why 20,000 Hours of Egocentric Human Video May Be the Scaling Law for Dexterous Robot Hands"
+slug: "egoscale-scaling-egocentric-human-video-dexterous-manipulation"
+date: "2026-05-16"
+author: "bob-jiang"
+category: "tutorials"
+tags: ["robotics", "dexterous-manipulation", "embodied-ai", "vision-language-action", "imitation-learning", "scaling-laws", "egocentric-video"]
+excerpt: "EgoScale shows that dexterous robot manipulation improves predictably as you scale action-labeled egocentric human video, bringing LLM-style scaling laws to robot policies."
+featured: true
+published: true
+seo:
+  title: "EgoScale Explained: Scaling Laws for Dexterous Robot Manipulation"
+  description: "A deep dive into EgoScale: 20k hours of egocentric human video, VLA policies, log-linear scaling laws, and why human data plus mid-training unlocks dexterous robot hands."
+  keywords: ["EgoScale", "dexterous manipulation", "egocentric human video", "VLA model", "robot scaling laws", "robot hand manipulation", "human to robot transfer"]
+---
+
+## Introduction: the uncomfortable truth about dexterous manipulation
+
+If you have ever tried to get a robot hand to do something boringly human, like roll a T-shirt, fold a towel, or pack an object into a bin without fumbling, you have already learned the lesson: **dexterous manipulation is not a planning problem first. It is a data problem.**
+
+The traditional playbook is familiar:
+
+- build a pipeline for demonstrations (teleoperation, kinesthetic teaching, VR, motion capture)
+- fight your way through control instability, contact modeling, and sensor noise
+- collect a little more data
+- tune a little more
+- repeat
+
+It works, but it does not scale. Not in the way foundation models scale.
+
+**EgoScale** is interesting because it argues (and provides evidence) that human behavior data can scale dexterous robot policies *predictably*, in a way that looks a lot like the scaling laws that powered large language models.
+
+Instead of asking “can we transfer a human demonstration to a robot once?”, EgoScale asks:
+
+- What happens if we train on **tens of thousands of hours** of egocentric human video with actions?
+- Do we see monotonic improvement, or do we hit a wall?
+- Is there a relationship between pretraining loss and real robot success that is stable enough to plan around?
+
+The headline: EgoScale trains a vision-language-action policy on **20,854 hours of action-labeled egocentric human video** and reports a **log-linear scaling law** between dataset size and validation loss, and that this loss correlates strongly with downstream robot performance. The resulting policy improves average success by **54% over a no-pretraining baseline** on a **22-DoF dexterous robotic hand**.
+
+In this post, we will unpack what EgoScale is really claiming, why the recipe matters, and what it implies for anyone trying to build dexterous robots that work outside carefully staged demos.
+
+## What EgoScale is (and what it is not)
+
+EgoScale is a **human-to-robot transfer framework** for dexterous manipulation built around a single thesis:
+
+> Effective dexterous human-to-robot transfer is fundamentally a scaling phenomenon.
+
+It is not a “one weird trick” paper with a single architectural novelty. It is closer to a systems result:
+
+- build a large human dataset that actually contains usable action signals
+- train a VLA policy at scale
+- show that more human data yields predictable gains
+- add a small mid-training step to align human and robot domains
+- post-train on a small set of downstream tasks
+
+The most practical value is that EgoScale tries to make dexterous robot learning feel less like alchemy and more like engineering: **if you can measure validation loss on the human pretraining distribution, you can predict robot policy quality before you ever touch a robot.**
+
+### Key numbers worth remembering
+
+From the paper and the NVIDIA project page:
+
+- **20,854 hours** of action-labeled egocentric human video (over 20× prior efforts)
+- discovered a **near-perfect log-linear scaling law** between data scale and validation loss (reported R²≈0.998)
+- validation loss **strongly correlates** with downstream real-robot performance
+- final policy: **+54% average success** vs no-pretraining baseline on a 22-DoF dexterous hand
+- transfer to **lower-DoF hands** suggests an “embodiment-agnostic motor prior”
+
+Sources:
+
+- EgoScale arXiv: https://arxiv.org/abs/2602.16710
+- NVIDIA EgoScale project page: https://research.nvidia.com/labs/gear/egoscale/
+
+## Why egocentric human video is the right scaling substrate
+
+A big reason dexterous manipulation is hard to scale is that **robot data is expensive**.
+
+- robots are slow
+- contact is brittle
+- failures are frequent
+- environments need resetting
+- safety constraints limit exploration
+
+Human data has the opposite properties:
+
+- humans generate manipulation trajectories constantly
+- data collection can be parallelized across many people
+- behavior covers long-horizon, contact-rich, messy skills naturally
+
+But there is an obvious catch: robots do not have human bodies.
+
+EgoScale’s bet is that if you capture human behavior in a way that preserves the **task-relevant structure of manipulation**, you can learn a reusable motor prior that is not tightly tied to a specific embodiment.
+
+Egocentric video helps because:
+
+- hands and objects are consistently in view
+- viewpoint is aligned with action intent (what the operator cares about)
+- it naturally captures multi-step tasks (not just single grasps)
+
+The missing piece is **action supervision** that is consistent enough to train a policy. EgoScale uses wrist motion and retargeted dexterous hand actions as supervision signals during pretraining, then uses a mid-training stage to align human and robot domains.
+
+## The EgoScale recipe: pretrain, mid-train, post-train
+
+EgoScale’s training pipeline is best understood as three stages.
+
+### Stage 1: large-scale human pretraining
+
+The first stage trains a vision-language-action (VLA) policy on the large human dataset.
+
+The core idea is not just “use more data” but “use more data *and keep getting returns*”. According to the NVIDIA page, scaling from roughly **1k hours to 20k hours** yields stable, monotonic improvements, while smaller datasets show early overfitting.
+
+What makes this meaningful is the claim that the relationship between data scale and validation loss follows a log-linear trend. If this holds broadly, it becomes a planning tool:
+
+- want a certain error reduction?
+- estimate how much more data you need
+- budget collection accordingly
+
+This is a big shift from typical robot learning work, where adding data often produces noisy, inconsistent gains.
+
+### Stage 2: aligned human-robot mid-training
+
+If you have ever tried to directly transfer human demonstrations to robot control, you already know the domain gap problems:
+
+- camera viewpoint differences
+- proprioception differences
+- action space differences
+- embodiment constraints
+
+EgoScale addresses this with a lightweight mid-training stage using **aligned human-robot play data**. The mid-training step adapts the representation to robot sensing and control while keeping the large human prior intact.
+
+Conceptually, mid-training plays the role that “instruction tuning” plays in LLMs: a relatively small dataset is used to reshape the model into a form that is more directly useful for the target setting.
+
+### Stage 3: downstream post-training
+
+Finally, the policy is post-trained on downstream dexterous tasks. EgoScale emphasizes efficiency here: the point is not to require a massive robot dataset per task.
+
+The project page highlights **one-shot task adaptation** with minimal robot supervision (for example, using very few robot demonstrations combined with aligned human demonstrations per object).
+
+The implication is that once you have a strong human prior, downstream robot learning looks less like training-from-scratch and more like adaptation.
+
+## Architecture: a VLA policy with a diffusion-style action component
+
+EgoScale describes a flow-based VLA setup with:
+
+- a VLM backbone (vision-language model) for perception and instruction conditioning
+- a DiT-like action expert (diffusion transformer style) for action generation
+- a shared wrist-level action representation to unify human and robot data
+- embodiment-specific adapters for proprioceptive inputs and hand actions
+
+You do not need to copy their exact architecture to learn from the result. The larger point is:
+
+1. modern VLA policies can absorb massive heterogeneous datasets
+2. diffusion/flow-style action models can represent complex, multimodal motor outputs
+3. adapters let you keep a shared prior while handling embodiment specifics
+
+For dexterous hands, that last point is crucial. It is easy to end up with a policy that “works” only on the exact hand used during training.
+
+## The scaling law claim: why it matters more than the benchmark score
+
+The flashiest number is the +54% success improvement, but the more strategically important claim is this:
+
+- **human pretraining validation loss tracks robot performance**
+
+Why do we care?
+
+Because robot evaluation is slow and expensive.
+
+If you can predict downstream performance from a cheap validation metric during human pretraining, you can run the entire robotics development loop more like a foundation-model org:
+
+- train multiple model sizes
+- train on multiple data mixes
+- compare learning curves
+- choose candidates before deploying on hardware
+
+This is what made LLM progress so fast: you could iterate in the model domain without waiting on expensive real-world evaluations.
+
+EgoScale is effectively arguing that **dexterous manipulation can inherit that iteration speed** if you treat large-scale human data as the main pretraining substrate.
+
+A third-party industry perspective (KraneShares) explicitly points to EgoScale as evidence that robotics foundation models follow LLM-like scaling laws:
+
+- https://kraneshares.com/humanoid-robotics-in-2026-the-race-from-pilot-to-platform/
+
+## What “embodiment-agnostic motor prior” really implies
+
+One of the most underrated lines in the abstract is that EgoScale transfers effectively to robots with **lower-DoF hands**.
+
+That suggests the model is learning something closer to:
+
+- intent-level motion primitives
+- contact-aware coordination patterns
+- object-centric manipulation strategies
+
+…rather than just memorizing joint-angle trajectories.
+
+If you are building products, this matters because hardware changes are inevitable:
+
+- suppliers change
+- hands get redesigned
+- sensors get swapped
+- actuators differ
+
+A policy that cannot survive these shifts is not deployable.
+
+The “motor prior” framing also fits a broader trend: as the community builds more generalist robot foundation models, the winners will likely be those who can learn reusable, composable skills rather than brittle, single-task controllers.
+
+## Where this fits in the 2026 robot learning landscape
+
+Robotics in 2026 is increasingly split into two fast-moving tracks:
+
+1. **deployment track**: robots clocking real hours in factories, airports, and warehouses
+2. **model track**: VLAs, diffusion policies, world models, and scaling recipes
+
+EgoScale sits squarely in the model track, but it supports the deployment track indirectly by attacking the main bottleneck: getting dexterous skills to a level where they can be adapted quickly and reliably.
+
+The industry is already leaning into the “data flywheel” thesis: collect more real-world interaction, train better models, deploy more robots, collect more data.
+
+EgoScale suggests a complementary strategy:
+
+- use **human behavior** as the high-volume data engine
+- use a small amount of robot data for alignment
+- use post-training for task specialization
+
+This is attractive because it can scale *before* you have a giant deployed robot fleet.
+
+## Practical takeaways: how to use EgoScale ideas in your own pipeline
+
+Even if you are not training on 20k hours tomorrow, the principles generalize.
+
+### 1) Stop treating human data as “nice to have”
+
+If your goal is dexterity, large-scale human behavior is not just an augmentation. It may be the primary pretraining substrate.
+
+Start thinking about:
+
+- what human signals you can capture cheaply (wrist pose, hand pose, gaze, tool usage)
+- what action representation will be stable across setups
+- what language or task labeling you need (even weak labels can help)
+
+### 2) Design for alignment, not perfect transfer
+
+EgoScale’s two-stage recipe is a reminder that you rarely get perfect sim-to-real or human-to-robot transfer.
+
+Instead:
+
+- learn the broad prior from scalable data
+- spend a little robot data on alignment
+
+In many practical systems, “alignment” is the highest leverage dataset you can collect.
+
+### 3) Make validation metrics meaningful
+
+The biggest win in productivity is having a metric you can trust.
+
+If you can establish even a loose correlation between an offline validation loss and real-world success, you can:
+
+- run ablation studies faster
+- justify scaling data collection
+- decide when a model is ready for expensive hardware tests
+
+### 4) Expect scaling to be logarithmic
+
+A log-linear scaling law means you get diminishing returns, but you still get returns.
+
+That changes planning:
+
+- doubling data might not double performance
+- but it may still provide predictable incremental gains
+
+In product terms, predictable incremental gains are gold because they make roadmaps realistic.
+
+## Limitations and open questions
+
+EgoScale is compelling, but there are important questions that remain.
+
+1. **Data requirements**: 20k hours is enormous. How far down the curve do these benefits persist? Is 500 hours meaningfully better than 50? Probably, but the exact slope matters.
+2. **Action labeling cost**: “action-labeled” is doing a lot of work here. The economics of labeling at scale will determine who can replicate this.
+3. **Task diversity vs hours**: is it sheer hours that matter, or diversity of objects and contexts? Likely both.
+4. **Safety and reliability**: dexterous skills in the lab are not the same as 99.9% uptime in production settings.
+
+Still, the direction is clear: the community is moving from “train a policy for a task” toward “pretrain a motor prior, then adapt.”
+
+## Conclusion: the scaling era is coming to robot hands
+
+EgoScale is one of the cleaner arguments so far that **dexterous manipulation can be made predictable** if you treat human behavior as the scalable data source and you measure the right thing.
+
+The practical lesson is simple:
+
+- if you want dexterous robots, you need a plan for scaling data
+- human egocentric behavior may be the cheapest way to do that
+- a small alignment dataset can bridge the human-to-robot gap
+- once you have a strong prior, downstream learning becomes adaptation, not reinvention
+
+If the scaling law result holds across other manipulation regimes, it will reshape how robotics teams budget their time: less “collect a few robot demos and pray” and more “scale the dataset and watch the curves.”
+
+### Further reading
+
+- EgoScale (arXiv): https://arxiv.org/abs/2602.16710
+- NVIDIA EgoScale project: https://research.nvidia.com/labs/gear/egoscale/
+- Industry context referencing EgoScale: https://kraneshares.com/humanoid-robotics-in-2026-the-race-from-pilot-to-platform/


### PR DESCRIPTION
## Summary
Deep dive into EgoScale (arXiv:2602.16710) and why scaling egocentric human video to 20,854 hours produces predictable improvements for dexterous robot hand manipulation.

## Key points
- Log-linear scaling law between human data scale and validation loss
- Validation loss correlates with downstream real-robot performance
- Two-stage transfer recipe: large-scale human pretraining + lightweight aligned human–robot mid-training
- +54% average success vs no-pretraining baseline on a 22-DoF dexterous hand

## Keywords
EgoScale, dexterous manipulation, egocentric video, VLA, scaling laws