### PR TITLE
Daily post: WarmPrior for flow-matching robot policies (2026-05-17)

### DIFF
--- a/content/blog/warmprior-flow-matching-policies-temporal-priors-robot-control.md
+++ b/content/blog/warmprior-flow-matching-policies-temporal-priors-robot-control.md
@@ -1,0 +1,200 @@
+---
+title: "WarmPrior: A Simple Trick That Makes Flow-Matching Robot Policies More Reliable"
+slug: "warmprior-flow-matching-policies-temporal-priors-robot-control"
+date: "2026-05-17"
+author: "bob-jiang"
+category: "tutorials"
+tags: ["robotics", "imitation learning", "diffusion policy", "flow matching", "visuomotor control", "generative models", "reinforcement learning"]
+excerpt: "WarmPrior replaces the usual Gaussian noise start with a history-conditioned prior, making flow-matching robot policies easier to integrate, more stable, and more successful in real control loops."
+featured: true
+published: true
+seo:
+  title: "WarmPrior: Stabilizing Flow-Matching Robot Policies"
+  description: "WarmPrior swaps the Gaussian source distribution for a temporal prior built from recent actions, improving flow-matching (diffusion-style) robot policies in real control."
+  keywords: ["WarmPrior", "flow matching policy", "diffusion policy robotics", "visuomotor control", "generative policies", "robot imitation learning", "policy fine-tuning"]
+---
+
+## The problem: generative policies are powerful, but control loops are unforgiving
+
+Over the last two years, **generative policies** (diffusion policies and flow-matching variants) have become one of the most effective ways to do **visuomotor robot control**: feed images and robot state into a model, then generate an action sequence.
+
+The promise is real:
+- They represent **multi-modal behaviors** naturally (there may be multiple valid grasps).
+- They can generate **smooth action trajectories** rather than single-step actions.
+- They often outperform simpler unimodal policies on manipulation benchmarks.
+
+The pain is also real:
+- At inference time you must integrate a stochastic process (diffusion steps or an ODE solver for flow matching).
+- Control needs **low latency** and **temporal consistency**. A small numerical wobble can become a physical wobble.
+- The standard setup typically starts generation from an **uninformative Gaussian** source distribution. That is mathematically convenient, but it is not aligned with what a robot is doing at time *t*: the robot is already executing an ongoing motion with momentum, constraints, and contact.
+
+WarmPrior is a clean, almost annoyingly simple idea: **start the generative process from something closer to the action you were just taking**.
+
+## WarmPrior in one sentence
+
+**WarmPrior** replaces the usual standard Gaussian source distribution used in flow-matching policies with a **temporal prior constructed from recent action history**, which tends to “straighten” the probability flow and makes inference more stable and more successful.
+
+Primary reference:
+- WarmPrior: Straightening Flow-Matching Policies with Temporal Priors (arXiv:2605.13959) — https://arxiv.org/abs/2605.13959
+
+Supporting context:
+- Generative Predictive Control: Flow Matching Policies for Dynamic and Difficult-to-Demonstrate Tasks (arXiv:2502.13406) — https://arxiv.org/abs/2502.13406
+- Diffusion Policy: Visuomotor Policy Learning via Action Diffusion (arXiv:2303.04137) — https://arxiv.org/abs/2303.04137
+- Flow Policy Gradients for Robot Control (arXiv:2602.02481) — https://arxiv.org/html/2602.02481v1
+
+## Why Gaussian starts are a mismatch for robots
+
+Most diffusion-style policies generate an action trajectory by starting from noise and progressively denoising. For flow matching policies, you can think of learning a **vector field** that transports samples from a source distribution (often Gaussian) to a target distribution (actions conditioned on observations).
+
+Gaussian source distributions are popular because:
+- Sampling is trivial.
+- Training objectives become clean.
+- They are generic and task-agnostic.
+
+But from a control perspective, a Gaussian start has two problems:
+
+### 1) It discards the robot’s momentum and intent
+
+If the robot has been moving its end-effector toward a handle for the last 200 ms, the next good action is typically “continue moving toward the handle, with a small correction”, not “sample a brand-new action trajectory from scratch”.
+
+### 2) It makes numerical integration harder than it needs to be
+
+When you start far from the likely action manifold, the learned flow has to do a lot of work to transport samples into a good region.
+
+Practically, that can mean:
+- More curvature in the probability path
+- More sensitivity to solver step size
+- More variance across samples
+- More jitter when you replan at high frequency
+
+WarmPrior is an attempt to reduce that gap.
+
+## The WarmPrior idea (intuitively)
+
+WarmPrior constructs the source distribution for the next planning step from **recent action history**. Instead of sampling an initial latent from N(0, I), you sample from something like:
+
+- “centered around the last action (or last few actions)”
+- potentially with noise shaped to match the model’s expected uncertainty
+
+The exact formulation is described in the paper, but the core control intuition is the same as warm-starting an optimizer:
+
+- You were already on a good trajectory.
+- Don’t throw it away.
+- Start near it, and only adjust what you must.
+
+If you have ever tuned MPC or trajectory optimization in robotics, WarmPrior should feel familiar.
+
+## How this changes the behavior of a flow-matching policy
+
+WarmPrior changes the *geometry* of the sampling problem. You can read the paper’s framing as:
+
+- Standard Gaussian starts create unnecessarily “bent” transport paths.
+- WarmPrior straightens them, so the solver has an easier job.
+
+In control terms, that tends to show up as:
+
+### Better temporal consistency
+
+Because consecutive replans begin from a related prior, the generated actions vary less violently between control ticks.
+
+### Higher success at the same compute budget
+
+If the transport problem is easier, you can often use fewer solver steps for similar quality, or get higher quality at the same number of steps.
+
+### Improved fine-tuning in prior space
+
+Many recent approaches adapt generative policies by modifying the prior or performing RL in a latent/prior space. A temporally grounded prior can be a better substrate for that kind of adaptation.
+
+## Where this fits in the bigger picture: diffusion policy vs flow matching
+
+Diffusion Policy (2023) made the “generate an action sequence by denoising” recipe mainstream for robot manipulation.
+
+Flow matching is a close cousin that often replaces discrete denoising steps with learning a continuous-time vector field. In practice, flow matching policies can be appealing because:
+- ODE solvers give you a knob for speed/accuracy tradeoffs.
+- Some formulations can be more stable or more efficient.
+
+WarmPrior is specifically targeted at **flow matching policies**, but the bigger lesson likely generalizes:
+
+> In real robots, the prior should reflect the fact that motion is continuous.
+
+## A concrete mental model: replanning every 50 ms
+
+Imagine a robot replanning at 20 Hz (every 50 ms):
+
+1. At time t, you observe camera + proprioception.
+2. The policy generates a short horizon of actions (say 1–2 seconds).
+3. You execute the first action (or first few).
+4. At time t+50 ms, you replan.
+
+With Gaussian starts, step (2) is like doing a full regeneration each time.
+
+With WarmPrior, step (2) is closer to:
+- take the previous plan
+- shift it forward
+- correct based on new observations
+
+This is exactly what strong classical controllers do. WarmPrior is a way to get some of that benefit while staying inside the expressive “generative policy” paradigm.
+
+## When WarmPrior is likely to help (and when it might not)
+
+### Good fits
+
+- **Contact-rich manipulation** where jitter hurts (handles, insertion, door opening)
+- **High-frequency feedback** tasks, where you must replan fast
+- **Real robot deployments** where solver stability matters more than benchmark novelty
+- **Policies that are already decent**, where warm-starting keeps you in a good basin
+
+### Potential weak spots
+
+- If your previous actions were bad (e.g., the robot is off-track), anchoring the prior to them can slow recovery.
+- In tasks that require abrupt strategy changes (multi-modal switching), overly strong temporal priors can reduce exploration.
+- If your observation stream changes discontinuously (camera dropouts, occlusions), you may want a weaker prior to avoid “hallucinated inertia”.
+
+A practical implementation should treat the temporal prior as a **knob**: how strongly do you anchor to history vs allow re-sampling diversity?
+
+## Practical takeaways for builders
+
+If you are shipping robot behaviors (not just publishing plots), WarmPrior points to three pragmatic moves:
+
+### 1) Treat the source distribution as a design choice
+
+Don’t default to N(0, I) because everyone does. The prior is part of your controller.
+
+### 2) Embrace warm-starting everywhere
+
+You already warm-start:
+- trajectory optimization
+- MPC
+- IK solvers
+- SLAM
+
+Warm-starting generative policies is the same instinct.
+
+### 3) Measure “control loop health”, not only task success
+
+When you evaluate a generative policy, track:
+- action smoothness
+- jerk/acceleration spikes
+- replanning variance
+- solver step sensitivity
+- failure modes under latency
+
+Those are the metrics that determine whether something survives contact with hardware.
+
+## What I would bet happens next
+
+WarmPrior is part of a broader trend: **generative policies are becoming more controller-like**.
+
+Expect to see more work that:
+- hybridizes diffusion/flow policies with MPC-style warm starts
+- makes inference adaptive (spend compute only when the state is hard)
+- learns priors that encode hardware constraints, safety envelopes, and contact regimes
+
+The winning stack will look less like “sample from scratch” and more like “continuous refinement of an evolving plan”.
+
+## References
+
+- WarmPrior: Straightening Flow-Matching Policies with Temporal Priors (arXiv:2605.13959) — https://arxiv.org/abs/2605.13959
+- Generative Predictive Control: Flow Matching Policies for Dynamic and Difficult-to-Demonstrate Tasks (arXiv:2502.13406) — https://arxiv.org/abs/2502.13406
+- Diffusion Policy: Visuomotor Policy Learning via Action Diffusion (arXiv:2303.04137) — https://arxiv.org/abs/2303.04137
+- Flow Policy Gradients for Robot Control (arXiv:2602.02481) — https://arxiv.org/html/2602.02481v1


### PR DESCRIPTION
## Summary\nExplains WarmPrior (arXiv:2605.13959): replacing the standard Gaussian source distribution in flow-matching robot policies with a temporal prior built from recent actions, improving stability and success in control loops.\n\n## Topic\nGenerative policies for visuomotor control (flow matching / diffusion-style), temporal priors, warm starting, and practical implications for real robots.\n\n## Keywords\nWarmPrior, flow matching, diffusion policy, visuomotor control, generative policies\n